### PR TITLE
Inclusion of original coroutines test utilities

### DIFF
--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/FlowTest.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/FlowTest.kt
@@ -1,0 +1,47 @@
+package com.mysugr.android.testing.example.coroutine
+
+import com.mysugr.android.testing.example.appModuleTestingConfiguration
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.coroutine.runBlockingSweetest
+import com.mysugr.sweetest.framework.coroutine.testCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.UncompletedCoroutinesError
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+@FlowPreview
+class FlowTest : BaseJUnitTest(appModuleTestingConfiguration) {
+
+    @Test
+    fun `Hot Flow with TestCoroutineScope is successful`() {
+        val channel = BroadcastChannel<Int>(1)
+        val emissions = mutableListOf<Int>()
+
+        channel.asFlow()
+            .onEach { emissions.add(it) }
+            .launchIn(testCoroutineScope)
+        channel.offer(1)
+
+        assertEquals(1, emissions.size)
+    }
+
+    @Test(expected = UncompletedCoroutinesError::class)
+    fun `Hot Flow produces error when not finished`() = runBlockingSweetest {
+        val channel = BroadcastChannel<Int>(1)
+        val emissions = mutableListOf<Int>()
+
+        channel.asFlow()
+            .onEach { emissions.add(it) }
+            .launchIn(testCoroutineScope)
+
+        channel.offer(1)
+        assertEquals(1, emissions.size)
+    }
+}

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/FlowTest.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/FlowTest.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.UncompletedCoroutinesError
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/FlowTestWithAutoCancel.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/FlowTestWithAutoCancel.kt
@@ -1,0 +1,35 @@
+package com.mysugr.android.testing.example.coroutine
+
+import com.mysugr.android.testing.example.appModuleTestingConfiguration
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.coroutine.runBlockingSweetest
+import com.mysugr.sweetest.framework.coroutine.testCoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.junit.Assert.assertEquals
+
+@ExperimentalCoroutinesApi
+@FlowPreview
+class FlowTestWithAutoCancel : BaseJUnitTest(appModuleTestingConfiguration) {
+
+    override fun configure() = super.configure()
+        .autoCancelTestCoroutines(true) // <-- !
+
+    fun `In contrast to FlowTest without auto cancel, here no exception is expected`() = runBlockingSweetest {
+        val channel = BroadcastChannel<Int>(1)
+        val emissions = mutableListOf<Int>()
+
+        channel.asFlow()
+            .onEach { emissions.add(it) }
+            .launchIn(testCoroutineScope)
+
+        channel.offer(1)
+        assertEquals(1, emissions.size)
+
+        // After the test sweetest automatically cancels the job created by `launchIn`
+    }
+}

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacySteps.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacySteps.kt
@@ -3,7 +3,7 @@ package com.mysugr.android.testing.example.coroutine
 import com.mysugr.android.testing.example.appModuleTestingConfiguration
 import com.mysugr.sweetest.framework.base.BaseSteps
 import com.mysugr.sweetest.framework.context.TestContext
-import com.mysugr.sweetest.framework.coroutine.coroutineScope
+import com.mysugr.sweetest.framework.coroutine.legacy.coroutineScope
 import com.mysugr.sweetest.framework.coroutine.throwExceptionIfFailed
 import com.mysugr.sweetest.framework.coroutine.verifyOrder
 import kotlinx.coroutines.async

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacySteps.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacySteps.kt
@@ -3,6 +3,7 @@ package com.mysugr.android.testing.example.coroutine
 import com.mysugr.android.testing.example.appModuleTestingConfiguration
 import com.mysugr.sweetest.framework.base.BaseSteps
 import com.mysugr.sweetest.framework.context.TestContext
+import com.mysugr.sweetest.framework.coroutine.coroutineScope
 import com.mysugr.sweetest.framework.coroutine.throwExceptionIfFailed
 import com.mysugr.sweetest.framework.coroutine.verifyOrder
 import kotlinx.coroutines.async
@@ -21,7 +22,7 @@ class TriggerAwaiterLegacySteps(testContext: TestContext) :
         verifyOrder {
             order(1)
 
-            val awaitJob = async {
+            val awaitJob = coroutineScope.async {
                 order(3)
                 sut.awaitTrigger()
                 triggerCompleted = true

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacySteps.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacySteps.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.yield
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 
-class TriggerAwaiterSteps(testContext: TestContext) :
+class TriggerAwaiterLegacySteps(testContext: TestContext) :
     BaseSteps(testContext, appModuleTestingConfiguration) {
 
     private val sut = TriggerAwaiter()
@@ -22,20 +22,23 @@ class TriggerAwaiterSteps(testContext: TestContext) :
             order(1)
 
             val awaitJob = async {
-                order(2)
+                order(3)
                 sut.awaitTrigger()
                 triggerCompleted = true
-                order(4)
+                order(5)
             }
 
-            order(3)
+            order(2)
+            yield() // allow awaitJob to get into awaitTrigger fun
+            order(4)
 
             awaitJob.throwExceptionIfFailed()
         }
     }
 
-    fun trigger() {
+    suspend fun trigger() {
         sut.trigger()
+        yield() // allow awaitJob to complete
     }
 
     fun assertAwaitTriggerCompleted() = assertTrue(triggerCompleted)

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacyTest.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacyTest.kt
@@ -3,20 +3,20 @@ package com.mysugr.android.testing.example.coroutine
 import com.mysugr.android.testing.example.appModuleTestingConfiguration
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
 import com.mysugr.sweetest.framework.base.steps
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
 import com.mysugr.sweetest.framework.coroutine.invoke
-import com.mysugr.sweetest.framework.coroutine.runBlockingSweetest
 import com.mysugr.sweetest.util.expectException
 import org.junit.Test
 
-class TriggerAwaiterTest : BaseJUnitTest(appModuleTestingConfiguration) {
+class TriggerAwaiterLegacyTest : BaseJUnitTest(appModuleTestingConfiguration) {
 
     override fun configure() = super.configure()
-        .autoCancelTestCoroutines(true)
+        .useLegacyCoroutineScope()
 
-    private val triggerAwaiter by steps<TriggerAwaiterSteps>()
+    private val triggerAwaiter by steps<TriggerAwaiterLegacySteps>()
 
     @Test
-    fun `awaitTrigger completes when triggered`() = runBlockingSweetest {
+    fun `awaitTrigger completes when triggered`() = testCoroutine {
         triggerAwaiter {
             startAwaitTrigger()
             trigger()
@@ -25,7 +25,7 @@ class TriggerAwaiterTest : BaseJUnitTest(appModuleTestingConfiguration) {
     }
 
     @Test
-    fun `awaitTrigger does not complete when triggered before`() = runBlockingSweetest {
+    fun `awaitTrigger does not complete when triggered before`() = testCoroutine {
         triggerAwaiter {
             trigger()
             startAwaitTrigger()
@@ -34,7 +34,7 @@ class TriggerAwaiterTest : BaseJUnitTest(appModuleTestingConfiguration) {
     }
 
     @Test
-    fun `awaitTrigger two times throws exception`() = runBlockingSweetest {
+    fun `awaitTrigger two times throws exception`() = testCoroutine {
         triggerAwaiter {
             startAwaitTrigger()
             expectException<IllegalStateException> {

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacyTest.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterLegacyTest.kt
@@ -3,7 +3,7 @@ package com.mysugr.android.testing.example.coroutine
 import com.mysugr.android.testing.example.appModuleTestingConfiguration
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
 import com.mysugr.sweetest.framework.base.steps
-import com.mysugr.sweetest.framework.coroutine.testCoroutine
+import com.mysugr.sweetest.framework.coroutine.legacy.testCoroutine
 import com.mysugr.sweetest.framework.coroutine.invoke
 import com.mysugr.sweetest.util.expectException
 import org.junit.Test
@@ -11,7 +11,7 @@ import org.junit.Test
 class TriggerAwaiterLegacyTest : BaseJUnitTest(appModuleTestingConfiguration) {
 
     override fun configure() = super.configure()
-        .useLegacyCoroutineScope()
+        .useLegacyCoroutineScope(true)
 
     private val triggerAwaiter by steps<TriggerAwaiterLegacySteps>()
 

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterSteps.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterSteps.kt
@@ -3,6 +3,7 @@ package com.mysugr.android.testing.example.coroutine
 import com.mysugr.android.testing.example.appModuleTestingConfiguration
 import com.mysugr.sweetest.framework.base.BaseSteps
 import com.mysugr.sweetest.framework.context.TestContext
+import com.mysugr.sweetest.framework.coroutine.coroutineScope
 import com.mysugr.sweetest.framework.coroutine.throwExceptionIfFailed
 import com.mysugr.sweetest.framework.coroutine.verifyOrder
 import kotlinx.coroutines.async
@@ -20,7 +21,7 @@ class TriggerAwaiterSteps(testContext: TestContext) :
         verifyOrder {
             order(1)
 
-            val awaitJob = async {
+            val awaitJob = coroutineScope.async {
                 order(2)
                 sut.awaitTrigger()
                 triggerCompleted = true

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterSteps.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterSteps.kt
@@ -6,7 +6,6 @@ import com.mysugr.sweetest.framework.context.TestContext
 import com.mysugr.sweetest.framework.coroutine.throwExceptionIfFailed
 import com.mysugr.sweetest.framework.coroutine.verifyOrder
 import kotlinx.coroutines.async
-import kotlinx.coroutines.yield
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 

--- a/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterTest.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/coroutine/TriggerAwaiterTest.kt
@@ -4,7 +4,7 @@ import com.mysugr.android.testing.example.appModuleTestingConfiguration
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
 import com.mysugr.sweetest.framework.base.steps
 import com.mysugr.sweetest.framework.coroutine.invoke
-import com.mysugr.sweetest.framework.coroutine.runBlockingSweetest
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
 import com.mysugr.sweetest.util.expectException
 import org.junit.Test
 
@@ -16,7 +16,7 @@ class TriggerAwaiterTest : BaseJUnitTest(appModuleTestingConfiguration) {
     private val triggerAwaiter by steps<TriggerAwaiterSteps>()
 
     @Test
-    fun `awaitTrigger completes when triggered`() = runBlockingSweetest {
+    fun `awaitTrigger completes when triggered`() = testCoroutine {
         triggerAwaiter {
             startAwaitTrigger()
             trigger()
@@ -25,7 +25,7 @@ class TriggerAwaiterTest : BaseJUnitTest(appModuleTestingConfiguration) {
     }
 
     @Test
-    fun `awaitTrigger does not complete when triggered before`() = runBlockingSweetest {
+    fun `awaitTrigger does not complete when triggered before`() = testCoroutine {
         triggerAwaiter {
             trigger()
             startAwaitTrigger()
@@ -34,7 +34,7 @@ class TriggerAwaiterTest : BaseJUnitTest(appModuleTestingConfiguration) {
     }
 
     @Test
-    fun `awaitTrigger two times throws exception`() = runBlockingSweetest {
+    fun `awaitTrigger two times throws exception`() = testCoroutine {
         triggerAwaiter {
             startAwaitTrigger()
             expectException<IllegalStateException> {

--- a/app/src/test/java/com/mysugr/android/testing/example/feature/AppCucumberHooks.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/feature/AppCucumberHooks.kt
@@ -4,6 +4,7 @@ import com.mysugr.sweetest.framework.context.TestContext
 import com.mysugr.sweetest.framework.cucumber.HookOrder
 import com.mysugr.sweetest.framework.environment.TestEnvironment
 import com.mysugr.sweetest.framework.flow.InitializationStep
+import cucumber.api.java.After
 import cucumber.api.java.Before
 
 class AppCucumberHooks(private val testContext: TestContext) {
@@ -26,5 +27,10 @@ class AppCucumberHooks(private val testContext: TestContext) {
     @Before(order = HookOrder.SETUP)
     fun setUp() {
         testContext.workflow.proceedTo(InitializationStep.SET_UP)
+    }
+
+    @After
+    fun tearDown() {
+        testContext.workflow.proceedTo(InitializationStep.TEAR_DOWN)
     }
 }

--- a/app/src/test/java/com/mysugr/android/testing/example/feature/AppCucumberHooks.kt
+++ b/app/src/test/java/com/mysugr/android/testing/example/feature/AppCucumberHooks.kt
@@ -12,6 +12,7 @@ class AppCucumberHooks(private val testContext: TestContext) {
     @Before(order = HookOrder.INITIALIZE_FRAMEWORK)
     fun initializeFramework() {
         TestEnvironment // force initialization
+        testContext.workflow.proceedTo(InitializationStep.INITIALIZE_FRAMEWORK)
     }
 
     @Before(order = HookOrder.INITIALIZE_STEPS)

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
             buildTools  : '28.0.2',
             gradlePlugin: '3.1.3',
             kotlin      : '1.3.10',
-            coroutines  : '1.0.1',
+            coroutines  : '1.3.2',
             support     : '27.1.1',
             cucumber    : '2.1.0',
             espresso    : '3.0.2',

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
             buildTools  : '28.0.2',
             gradlePlugin: '3.1.3',
             kotlin      : '1.3.10',
-            coroutines  : '1.3.2',
+            coroutines  : '1.3.3',
             support     : '27.1.1',
             cucumber    : '2.1.0',
             espresso    : '3.0.2',

--- a/sweetest/build.gradle
+++ b/sweetest/build.gradle
@@ -46,10 +46,13 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.coroutines"
-    api "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
+
     api "org.mockito:mockito-core:$versions.mockito"
     api "io.cucumber:cucumber-junit:$versions.cucumber"
     api "io.cucumber:cucumber-jvm:$versions.cucumber"
     api "io.cucumber:cucumber-picocontainer:$versions.cucumber"
     api "junit:junit:4.12"
+
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$versions.coroutines"
 }

--- a/sweetest/build.gradle
+++ b/sweetest/build.gradle
@@ -48,11 +48,11 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.coroutines"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
 
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-test:$versions.coroutines"
     api "org.mockito:mockito-core:$versions.mockito"
     api "io.cucumber:cucumber-junit:$versions.cucumber"
     api "io.cucumber:cucumber-jvm:$versions.cucumber"
     api "io.cucumber:cucumber-picocontainer:$versions.cucumber"
     api "junit:junit:4.12"
 
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$versions.coroutines"
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseJUnitTest.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseJUnitTest.kt
@@ -2,6 +2,7 @@ package com.mysugr.sweetest.framework.base
 
 import com.mysugr.sweetest.framework.build.TestBuilder
 import com.mysugr.sweetest.framework.configuration.ModuleTestingConfiguration
+import org.junit.After
 import org.junit.Before
 
 abstract class BaseJUnitTest(private val moduleTestingConfiguration: ModuleTestingConfiguration) : TestingAccessor {
@@ -15,5 +16,10 @@ abstract class BaseJUnitTest(private val moduleTestingConfiguration: ModuleTesti
     @Before
     fun junitBefore() {
         accessor.testContext.workflow.run()
+    }
+
+    @After
+    fun junitAfter() {
+        accessor.testContext.workflow.finish()
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseJUnitTest.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseJUnitTest.kt
@@ -2,6 +2,7 @@ package com.mysugr.sweetest.framework.base
 
 import com.mysugr.sweetest.framework.build.TestBuilder
 import com.mysugr.sweetest.framework.configuration.ModuleTestingConfiguration
+import com.mysugr.sweetest.framework.flow.InitializationStep
 import org.junit.After
 import org.junit.Before
 
@@ -12,6 +13,10 @@ abstract class BaseJUnitTest(private val moduleTestingConfiguration: ModuleTesti
     override val accessor = configure().build()
     protected val dependencies = accessor.dependencies
     protected val delegates = accessor.delegates
+
+    init {
+        accessor.testContext.workflow.proceedTo(InitializationStep.INITIALIZE_FRAMEWORK)
+    }
 
     @Before
     fun junitBefore() {

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
@@ -6,7 +6,7 @@ import com.mysugr.sweetest.framework.context.TestContext
 import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.CoroutineContext
 
-interface Steps : CoroutineScope
+interface Steps
 
 abstract class BaseSteps(
     private val testContext: TestContext,
@@ -14,13 +14,6 @@ abstract class BaseSteps(
 ) : Steps, TestingAccessor {
 
     open fun configure() = StepsBuilder(this, testContext, moduleTestingConfiguration)
-
-    @Deprecated(
-        "Don't use steps directly to get a CoroutineScope " +
-            "for testing, use coroutineScope extension instead"
-    )
-    override val coroutineContext: CoroutineContext
-        get() = testContext.coroutines.coroutineScope.coroutineContext
 
     override val accessor = configure().build()
     protected val dependencies = accessor.dependencies

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
@@ -15,8 +15,12 @@ abstract class BaseSteps(
 
     open fun configure() = StepsBuilder(this, testContext, moduleTestingConfiguration)
 
+    @Deprecated(
+        "Don't use steps directly to get a CoroutineScope " +
+            "for testing, use coroutineScope extension instead"
+    )
     override val coroutineContext: CoroutineContext
-        get() = testContext.coroutines.coroutineContext
+        get() = testContext.coroutines.coroutineScope.coroutineContext
 
     override val accessor = configure().build()
     protected val dependencies = accessor.dependencies

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
@@ -3,8 +3,6 @@ package com.mysugr.sweetest.framework.base
 import com.mysugr.sweetest.framework.build.StepsBuilder
 import com.mysugr.sweetest.framework.configuration.ModuleTestingConfiguration
 import com.mysugr.sweetest.framework.context.TestContext
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.CoroutineContext
 
 interface Steps
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
@@ -135,9 +135,9 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
      * [kotlinx.coroutines.test.TestCoroutineScope.cleanupTestCoroutines] is called after each test. That ensures that
      * all jobs in the TestCoroutineScope are finished.
      */
-    fun autoCleanupTestCoroutines(value: Boolean) = apply {
+    fun autoCancelTestCoroutines(value: Boolean) = apply {
         testContext.coroutines.configure {
-            autoCleanupTestCoroutines(value)
+            autoCancelTestCoroutines(value)
         }
     }
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
@@ -121,8 +121,12 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
     }
 
     /**
-     * By default [kotlinx.coroutines.Dispatchers.Main] is set to the CoroutineScope provided by sweetest before each
-     * test and also reset after. With this function this behavior can be forced to be disabled or enabled.
+     * [kotlinx.coroutines.Dispatchers.Main] can be set to the CoroutineScope provided by sweetest before each
+     * test and also reset it after. This behavior is **enabled by default**, but with this function it can be forced to
+     * be disabled or enabled for a test.
+     *
+     * If there are conflicting calls to this function, an exception is thrown (e.g. in the test `true` is passed, but
+     * in one of the steps `false` is passed).
      */
     fun autoSetMainCoroutineDispatcher(value: Boolean) = apply {
         testContext.coroutines.configure {
@@ -131,9 +135,13 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
     }
 
     /**
-     * By enabling this option sweetest can automatically take care that
-     * [kotlinx.coroutines.test.TestCoroutineScope.cleanupTestCoroutines] is called after each test. That ensures that
-     * all jobs in the TestCoroutineScope are finished.
+     * By enabling this option sweetest can automatically take care that all children jobs of the main test coroutine
+     * are cancelled if they are still active after the test. This behavior is **disabled by default** in order to help
+     * you catching failures where some logic does not finish a job as intended. So please use this feature just in
+     * places where you expect jobs to be still open in _every_ case.
+     *
+     * If there are conflicting calls to this function, an exception is thrown (e.g. in the test `true` is passed, but
+     * in one of the steps `false` is passed).
      */
     fun autoCancelTestCoroutines(value: Boolean) = apply {
         testContext.coroutines.configure {

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
@@ -48,9 +48,13 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
         return this as TSelf
     }
 
+    // STEPS
+
     inline fun <reified T : Steps> requireSteps() = apply {
         testContext.steps.setUpAsRequired(T::class as KClass<Steps>)
     }
+
+    // DEPENDENCIES
 
     inline fun <reified T : Any> requireReal() = apply {
         testContext.dependencies.requireReal(T::class)
@@ -80,6 +84,8 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
         testContext.dependencies.requireSpy(T::class)
     }
 
+    // FACTORY
+
     inline fun <reified R : Any> offerFactory(noinline createObject: () -> R) = apply {
         testContext.factories.configure(FactoryRunner0(R::class.java, createObject))
     }
@@ -100,6 +106,21 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
         testContext.factories.configure(FactoryRunner3(R::class.java, T1::class.java, T2::class.java, T3::class.java,
             createObject))
     }
+
+    // COROUTINES
+
+    /**
+     * sweetest uses and exposes [kotlinx.coroutines.test.TestCoroutineScope] as a standard way to test with coroutines,
+     * but before that was available sweetest had its own solution which can still be used by enabling this option (see
+     * [com.mysugr.sweetest.framework.coroutine.testCoroutine]).
+     */
+    fun useLegacyCoroutineScope() = apply {
+        testContext.coroutines.configure {
+            useLegacyCoroutineScope()
+        }
+    }
+
+    // TEST WORKFLOW EVENTS
 
     fun onInitializeDependencies(run: () -> Unit) = apply {
         checkNotYetBuilt()

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
@@ -11,6 +11,7 @@ import com.mysugr.sweetest.framework.factory.FactoryRunner2
 import com.mysugr.sweetest.framework.factory.FactoryRunner3
 import com.mysugr.sweetest.framework.flow.InitializationStep.INITIALIZE_DEPENDENCIES
 import com.mysugr.sweetest.framework.flow.InitializationStep.SET_UP
+import com.mysugr.sweetest.framework.flow.InitializationStep.TEAR_DOWN
 import kotlin.reflect.KClass
 
 abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
@@ -110,5 +111,8 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
         testContext.workflow.subscribe(SET_UP, run)
     }
 
-    // TODO onTearDown
+    fun onTearDown(run: () -> Unit) = apply {
+        checkNotYetBuilt()
+        testContext.workflow.subscribe(TEAR_DOWN, run)
+    }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
@@ -122,12 +122,22 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
 
     /**
      * By default [kotlinx.coroutines.Dispatchers.Main] is set to the CoroutineScope provided by sweetest before each
-     * test and also reset after. With this function this behavior can be forced to be disabled or enabled so it can't
-     * be changed subsequently anymore.
+     * test and also reset after. With this function this behavior can be forced to be disabled or enabled.
      */
     fun autoSetMainCoroutineDispatcher(value: Boolean) = apply {
         testContext.coroutines.configure {
             autoSetMainCoroutineDispatcher(value)
+        }
+    }
+
+    /**
+     * By enabling this option sweetest can automatically take care that
+     * [kotlinx.coroutines.test.TestCoroutineScope.cleanupTestCoroutines] is called after each test. That ensures that
+     * all jobs in the TestCoroutineScope are finished.
+     */
+    fun autoCleanupTestCoroutines(value: Boolean) = apply {
+        testContext.coroutines.configure {
+            autoCleanupTestCoroutines(value)
         }
     }
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
@@ -120,6 +120,17 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
         }
     }
 
+    /**
+     * By default [kotlinx.coroutines.Dispatchers.Main] is set to the CoroutineScope provided by sweetest before each
+     * test and also reset after. With this function this behavior can be forced to be disabled or enabled so it can't
+     * be changed subsequently anymore.
+     */
+    fun autoSetMainCoroutineDispatcher(value: Boolean) = apply {
+        testContext.coroutines.configure {
+            autoSetMainCoroutineDispatcher(value)
+        }
+    }
+
     // TEST WORKFLOW EVENTS
 
     fun onInitializeDependencies(run: () -> Unit) = apply {

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/BaseBuilder.kt
@@ -110,17 +110,6 @@ abstract class BaseBuilder<TSelf, TResult : BaseAccessor>(
     // COROUTINES
 
     /**
-     * sweetest uses and exposes [kotlinx.coroutines.test.TestCoroutineScope] as a standard way to test with coroutines,
-     * but before that was available sweetest had its own solution which can still be used by enabling this option (see
-     * [com.mysugr.sweetest.framework.coroutine.testCoroutine]).
-     */
-    fun useLegacyCoroutineScope() = apply {
-        testContext.coroutines.configure {
-            useLegacyCoroutineScope()
-        }
-    }
-
-    /**
      * [kotlinx.coroutines.Dispatchers.Main] can be set to the CoroutineScope provided by sweetest before each
      * test and also reset it after. This behavior is **enabled by default**, but with this function it can be forced to
      * be disabled or enabled for a test.

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/StepsBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/StepsBuilder.kt
@@ -12,11 +12,26 @@ class StepsBuilder(
 ) :
     BaseBuilder<StepsBuilder, StepsAccessor>(testContext, moduleTestingConfiguration) {
 
+    init {
+        testContext.steps.setUpInstance(instance)
+    }
+
     override fun buildInternal(): StepsAccessor {
         return StepsAccessor(testContext)
     }
 
-    init {
-        testContext.steps.setUpInstance(instance)
+    /**
+     * sweetest uses and exposes [kotlinx.coroutines.test.TestCoroutineScope] as a standard way to test with coroutines,
+     * but before that was available sweetest had its own solution which can still be used by enabling this option (see
+     * [com.mysugr.sweetest.framework.coroutine.testCoroutine]).
+     *
+     * Sidenote: This can just be configured on test level because coroutines capabilities need to be initialized very
+     * early in the initialization process. But it can be put as an expectation in steps so you receive an exception
+     * when the expectations are different from the test.
+     */
+    fun useLegacyCoroutineScope(value: Boolean) = apply {
+        testContext.coroutines.configure {
+            useLegacyCoroutineScopeOnStepsLevel(value)
+        }
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/TestBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/TestBuilder.kt
@@ -16,4 +16,18 @@ class TestBuilder(moduleTestingConfiguration: ModuleTestingConfiguration) :
         checkNotYetBuilt()
         testContext.workflow.subscribe(INITIALIZE_STEPS, run)
     }
+
+    /**
+     * sweetest uses and exposes [kotlinx.coroutines.test.TestCoroutineScope] as a standard way to test with coroutines,
+     * but before that was available sweetest had its own solution which can still be used by enabling this option (see
+     * [com.mysugr.sweetest.framework.coroutine.testCoroutine]).
+     *
+     * Sidenote: This can just be configured on test level because coroutines capabilities need to be initialized very
+     * early in the initialization process.
+     */
+    fun useLegacyCoroutineScope() = apply {
+        testContext.coroutines.configure {
+            useLegacyCoroutineScope()
+        }
+    }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/build/TestBuilder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/build/TestBuilder.kt
@@ -23,11 +23,12 @@ class TestBuilder(moduleTestingConfiguration: ModuleTestingConfiguration) :
      * [com.mysugr.sweetest.framework.coroutine.testCoroutine]).
      *
      * Sidenote: This can just be configured on test level because coroutines capabilities need to be initialized very
-     * early in the initialization process.
+     * early in the initialization process. But it can be put as an expectation in steps so you receive an exception
+     * when the expectations are different from the test.
      */
-    fun useLegacyCoroutineScope() = apply {
+    fun useLegacyCoroutineScope(value: Boolean) = apply {
         testContext.coroutines.configure {
-            useLegacyCoroutineScope()
+            useLegacyCoroutineScopeOnTestLevel(value)
         }
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/TestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/TestContext.kt
@@ -1,6 +1,6 @@
 package com.mysugr.sweetest.framework.context
 
-import com.mysugr.sweetest.framework.coroutine.CoroutinesTestContextProvider
+import com.mysugr.sweetest.framework.coroutine.CoroutinesTestContextWrapper
 import com.mysugr.sweetest.framework.environment.TestEnvironment
 
 class TestContext internal constructor() {
@@ -20,7 +20,7 @@ class TestContext internal constructor() {
     val workflow = WorkflowTestContext(steps)
 
     @PublishedApi
-    internal val coroutines = CoroutinesTestContextProvider(workflow)
+    internal val coroutines = CoroutinesTestContextWrapper(workflow)
 
     init {
         TestEnvironment.reset()

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/TestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/TestContext.kt
@@ -17,10 +17,10 @@ class TestContext internal constructor() {
     @PublishedApi
     internal val dependencies = DependenciesTestContext()
 
-    @PublishedApi
-    internal val coroutines = CoroutinesTestContextProvider()
-
     val workflow = WorkflowTestContext(steps)
+
+    @PublishedApi
+    internal val coroutines = CoroutinesTestContextProvider(workflow)
 
     init {
         TestEnvironment.reset()

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/TestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/TestContext.kt
@@ -1,6 +1,6 @@
 package com.mysugr.sweetest.framework.context
 
-import com.mysugr.sweetest.framework.coroutine.CoroutinesTestContext
+import com.mysugr.sweetest.framework.coroutine.CoroutinesTestContextProvider
 import com.mysugr.sweetest.framework.environment.TestEnvironment
 
 class TestContext internal constructor() {
@@ -17,7 +17,8 @@ class TestContext internal constructor() {
     @PublishedApi
     internal val dependencies = DependenciesTestContext()
 
-    internal val coroutines = CoroutinesTestContext()
+    @PublishedApi
+    internal val coroutines = CoroutinesTestContextProvider()
 
     val workflow = WorkflowTestContext(steps)
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
@@ -3,7 +3,6 @@ package com.mysugr.sweetest.framework.context
 import com.mysugr.sweetest.framework.flow.InitializationStep
 import com.mysugr.sweetest.framework.flow.InitializationStep.DONE
 import com.mysugr.sweetest.framework.flow.InitializationStep.INITIALIZE_DEPENDENCIES
-import com.mysugr.sweetest.framework.flow.InitializationStep.INITIALIZE_FRAMEWORK
 import com.mysugr.sweetest.framework.flow.InitializationStep.RUNNING
 import com.mysugr.sweetest.framework.flow.InitializationStep.UNINITIALIZED
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
@@ -5,10 +5,11 @@ import com.mysugr.sweetest.framework.flow.InitializationStep.DONE
 import com.mysugr.sweetest.framework.flow.InitializationStep.INITIALIZE_DEPENDENCIES
 import com.mysugr.sweetest.framework.flow.InitializationStep.INITIALIZE_FRAMEWORK
 import com.mysugr.sweetest.framework.flow.InitializationStep.RUNNING
+import com.mysugr.sweetest.framework.flow.InitializationStep.UNINITIALIZED
 
 class WorkflowTestContext internal constructor(private val steps: StepsTestContext) {
 
-    var currentStep: InitializationStep = INITIALIZE_FRAMEWORK
+    var currentStep: InitializationStep = UNINITIALIZED
         private set
 
     private val stepHandlers =
@@ -25,7 +26,7 @@ class WorkflowTestContext internal constructor(private val steps: StepsTestConte
     fun proceedTo(step: InitializationStep) {
         if (step.isBeforeOrSame(currentStep)) {
             throw IllegalStateException("The workflow is already at $currentStep, can't proceed to $step")
-        } else if (step == DONE || step == INITIALIZE_FRAMEWORK) {
+        } else if (step == DONE || step == UNINITIALIZED) {
             throw IllegalStateException("It's not allowed to proceed to DONE or INITIALIZE_FRAMEWORK")
         }
         runStep(step)

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesExtensions.kt
@@ -52,20 +52,3 @@ suspend fun Deferred<*>.throwExceptionIfFailed() {
         await() // throws exception, if Deferred failed. Does nothing otherwise
     }
 }
-
-/**
- * With multiple child jobs, you may want to yield multiple times to ensure each child can finish.
- * This function counts the number of child jobs and calls [yield] the number of times as jobs are present.
- */
-@Suppress("SuspendFunctionOnCoroutineScope")
-suspend fun CoroutineScope.yieldForEachJob() {
-    val job =
-        this.coroutineContext[Job.Key] ?: error(
-            "coroutineContext doesn't have a parent Job. Probably you are mistakenly using a TestCoroutineScope " +
-                "(these don't have a `Job` by default) or you don't use sweetest's legacy CoroutineScope. Pleas bear " +
-                "in mind that with runBlockingTest/Sweetest and TestCoroutineScope you don't need `yield` usually!"
-        )
-    kotlin.repeat(countJobs(job)) { yield() }
-}
-
-private fun countJobs(job: Job): Int = 1 + job.children.sumBy { countJobs(it) }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesExtensions.kt
@@ -3,14 +3,11 @@ package com.mysugr.sweetest.framework.coroutine
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
 import com.mysugr.sweetest.framework.base.Steps
 import com.mysugr.sweetest.framework.base.TestingAccessor
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.DelayController
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.UncaughtExceptionCaptor
-import kotlinx.coroutines.yield
 
 /**
  * Imitates [kotlinx.coroutines.test.runBlockingTest] and uses the [TestCoroutineScope] provided by sweetest. You can

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
@@ -1,9 +1,28 @@
 package com.mysugr.sweetest.framework.coroutine
 
-internal class CoroutinesTestConfiguration {
-    var data = CoroutinesTestConfigurationData()
+interface CoroutinesTestConfigurator {
 
-    fun useLegacyCoroutineScope() {
+    fun useLegacyCoroutineScope()
+
+    /**
+     * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
+     * system
+     */
+    fun autoSetMainCoroutineDispatcher(value: Boolean)
+
+    /**
+     * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
+     * system
+     */
+    fun autoCancelTestCoroutines(value: Boolean)
+}
+
+internal class CoroutinesTestConfiguration : CoroutinesTestConfigurator {
+
+    var data = CoroutinesTestConfigurationData()
+        private set
+
+    override fun useLegacyCoroutineScope() {
         data = data.copy(
             useLegacyTestCoroutine = true
         )
@@ -13,7 +32,7 @@ internal class CoroutinesTestConfiguration {
      * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
      * system
      */
-    fun autoSetMainCoroutineDispatcher(value: Boolean) {
+    override fun autoSetMainCoroutineDispatcher(value: Boolean) {
         val previousValue = data.autoSetMainCoroutineDispatcher
         if (previousValue != null && previousValue != value) {
             error(getCantChangeErrorMessage("autoSetMainCoroutineDispatcher", previousValue))
@@ -28,7 +47,7 @@ internal class CoroutinesTestConfiguration {
      * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
      * system
      */
-    fun autoCancelTestCoroutines(value: Boolean) {
+    override fun autoCancelTestCoroutines(value: Boolean) {
         val previousValue = data.autoCancelTestCoroutines
         if (previousValue != null && previousValue != value) {
             error(getCantChangeErrorMessage("autoCancelTestCoroutines", previousValue))

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
@@ -41,7 +41,7 @@ internal class CoroutinesTestConfiguration {
 
     private fun getCantChangeErrorMessage(property: String, previousValue: Boolean): String {
         return "$property was set to $previousValue before somewhere in your test system, " +
-            "it can't be enabled anymore. This error is to ensure consistent expectations throughout " +
+            "it can't be changed anymore. This error is to ensure consistent expectations throughout " +
             "your test system."
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
@@ -28,13 +28,13 @@ internal class CoroutinesTestConfiguration {
      * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
      * system
      */
-    fun autoCleanupTestCoroutines(value: Boolean) {
-        val previousValue = data.autoCleanupTestCoroutines
+    fun autoCancelTestCoroutines(value: Boolean) {
+        val previousValue = data.autoCancelTestCoroutines
         if (previousValue != null && previousValue != value) {
-            error(getCantChangeErrorMessage("autoCleanupTestCoroutines", previousValue))
+            error(getCantChangeErrorMessage("autoCancelTestCoroutines", previousValue))
         } else {
             data = data.copy(
-                autoCleanupTestCoroutines = value
+                autoCancelTestCoroutines = value
             )
         }
     }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
@@ -8,4 +8,19 @@ internal class CoroutinesTestConfiguration {
             useLegacyTestCoroutine = true
         )
     }
+
+    fun autoSetMainCoroutineDispatcher(value: Boolean) {
+        val previousValue = data.autoSetMainCoroutineDispatcher
+        if (previousValue != null && previousValue != value) {
+            error(
+                "autoSetMainCoroutineDispatcher was set to $previousValue before somewhere in your test system, " +
+                    "it can't be enabled anymore. This error is to ensure consistent expectations throughout " +
+                    "your test system."
+            )
+        } else {
+            data = data.copy(
+                autoSetMainCoroutineDispatcher = value
+            )
+        }
+    }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
@@ -1,19 +1,34 @@
 package com.mysugr.sweetest.framework.coroutine
 
+/**
+ * The configurator makes sure that there can not be any conflicting configurations.
+ *
+ * **Example 1:**
+ * - Test calls [autoSetMainCoroutineDispatcher] with argument `false`
+ * - One of its steps classes calls [autoSetMainCoroutineDispatcher] with argument `true` --> causes exception
+ *
+ * **Example 2:**
+ * - Test calls [autoSetMainCoroutineDispatcher] with argument `false`
+ * - One of its steps classes calls [autoSetMainCoroutineDispatcher] with argument `false` --> OK
+ * - Result: [autoSetMainCoroutineDispatcher] is ultimately `false`
+ *
+ * However, [useLegacyCoroutineScope] has a slightly different behavior, as its state has to be known at the time of
+ * test initialization to allow early access to a [kotlinx.coroutines.CoroutineScope]. Therefore if you want a test to
+ * have a legacy coroutines behavior, you _have to_ specify that on the test level.
+ *
+ * **Example 3:**
+ * - Test doesn't call `useLegacyCoroutineScope`
+ * - Result: `false` (use default coroutine behavior)
+ * - A steps class calls `useLegacyCoroutineScope(true)` --> exception
+ */
 interface CoroutinesTestConfigurator {
 
-    fun useLegacyCoroutineScope()
+    fun useLegacyCoroutineScopeOnTestLevel(value: Boolean)
 
-    /**
-     * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
-     * system
-     */
+    fun useLegacyCoroutineScopeOnStepsLevel(value: Boolean)
+
     fun autoSetMainCoroutineDispatcher(value: Boolean)
 
-    /**
-     * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
-     * system
-     */
     fun autoCancelTestCoroutines(value: Boolean)
 }
 
@@ -22,16 +37,29 @@ internal class CoroutinesTestConfiguration : CoroutinesTestConfigurator {
     var data = CoroutinesTestConfigurationData()
         private set
 
-    override fun useLegacyCoroutineScope() {
+    override fun useLegacyCoroutineScopeOnTestLevel(value: Boolean) {
+        val previousValue = data.useLegacyTestCoroutine
+        require(previousValue == null || previousValue == value) {
+            getCantChangeErrorMessage(
+                "useLegacyTestCoroutine",
+                previousValue!!
+            )
+        }
         data = data.copy(
-            useLegacyTestCoroutine = true
+            useLegacyTestCoroutine = value
         )
     }
 
-    /**
-     * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
-     * system
-     */
+    override fun useLegacyCoroutineScopeOnStepsLevel(value: Boolean) {
+        val previousValue = data.useLegacyTestCoroutine
+        require(previousValue == null || previousValue == value) {
+            getCanOnlyBeSetOnTestLevelErrorMessage(
+                "useLegacyTestCoroutine",
+                previousValue!!
+            )
+        }
+    }
+
     override fun autoSetMainCoroutineDispatcher(value: Boolean) {
         val previousValue = data.autoSetMainCoroutineDispatcher
         require(previousValue == null || previousValue == value) {
@@ -45,10 +73,6 @@ internal class CoroutinesTestConfiguration : CoroutinesTestConfigurator {
         )
     }
 
-    /**
-     * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
-     * system
-     */
     override fun autoCancelTestCoroutines(value: Boolean) {
         val previousValue = data.autoCancelTestCoroutines
         require(previousValue == null || previousValue == value) {
@@ -63,5 +87,10 @@ internal class CoroutinesTestConfiguration : CoroutinesTestConfigurator {
         return "$property was set to $previousValue before somewhere in your test system, " +
             "it can't be changed anymore. This error is to ensure consistent expectations throughout " +
             "your test system."
+    }
+
+    private fun getCanOnlyBeSetOnTestLevelErrorMessage(property: String, previousValue: Boolean): String {
+        return "$property was set to $previousValue before at the test level, it can't be changed anymore. " +
+            "This specific property is not possible to be changed on a steps level, too."
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
@@ -34,13 +34,15 @@ internal class CoroutinesTestConfiguration : CoroutinesTestConfigurator {
      */
     override fun autoSetMainCoroutineDispatcher(value: Boolean) {
         val previousValue = data.autoSetMainCoroutineDispatcher
-        if (previousValue != null && previousValue != value) {
-            error(getCantChangeErrorMessage("autoSetMainCoroutineDispatcher", previousValue))
-        } else {
-            data = data.copy(
-                autoSetMainCoroutineDispatcher = value
+        require(previousValue == null || previousValue == value) {
+            getCantChangeErrorMessage(
+                "autoSetMainCoroutineDispatcher",
+                previousValue!!
             )
         }
+        data = data.copy(
+            autoSetMainCoroutineDispatcher = value
+        )
     }
 
     /**
@@ -49,13 +51,12 @@ internal class CoroutinesTestConfiguration : CoroutinesTestConfigurator {
      */
     override fun autoCancelTestCoroutines(value: Boolean) {
         val previousValue = data.autoCancelTestCoroutines
-        if (previousValue != null && previousValue != value) {
-            error(getCantChangeErrorMessage("autoCancelTestCoroutines", previousValue))
-        } else {
-            data = data.copy(
-                autoCancelTestCoroutines = value
-            )
+        require(previousValue == null || previousValue == value) {
+            getCantChangeErrorMessage("autoCancelTestCoroutines", previousValue!!)
         }
+        data = data.copy(
+            autoCancelTestCoroutines = value
+        )
     }
 
     private fun getCantChangeErrorMessage(property: String, previousValue: Boolean): String {

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
@@ -9,18 +9,39 @@ internal class CoroutinesTestConfiguration {
         )
     }
 
+    /**
+     * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
+     * system
+     */
     fun autoSetMainCoroutineDispatcher(value: Boolean) {
         val previousValue = data.autoSetMainCoroutineDispatcher
         if (previousValue != null && previousValue != value) {
-            error(
-                "autoSetMainCoroutineDispatcher was set to $previousValue before somewhere in your test system, " +
-                    "it can't be enabled anymore. This error is to ensure consistent expectations throughout " +
-                    "your test system."
-            )
+            error(getCantChangeErrorMessage("autoSetMainCoroutineDispatcher", previousValue))
         } else {
             data = data.copy(
                 autoSetMainCoroutineDispatcher = value
             )
         }
+    }
+
+    /**
+     * This configuration can be set multiple times but not changed. This prevents conflicting expectations in the test
+     * system
+     */
+    fun autoCleanupTestCoroutines(value: Boolean) {
+        val previousValue = data.autoCleanupTestCoroutines
+        if (previousValue != null && previousValue != value) {
+            error(getCantChangeErrorMessage("autoCleanupTestCoroutines", previousValue))
+        } else {
+            data = data.copy(
+                autoCleanupTestCoroutines = value
+            )
+        }
+    }
+
+    private fun getCantChangeErrorMessage(property: String, previousValue: Boolean): String {
+        return "$property was set to $previousValue before somewhere in your test system, " +
+            "it can't be enabled anymore. This error is to ensure consistent expectations throughout " +
+            "your test system."
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfiguration.kt
@@ -1,0 +1,11 @@
+package com.mysugr.sweetest.framework.coroutine
+
+internal class CoroutinesTestConfiguration {
+    var data = CoroutinesTestConfigurationData()
+
+    fun useLegacyCoroutineScope() {
+        data = data.copy(
+            useLegacyTestCoroutine = true
+        )
+    }
+}

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
@@ -1,0 +1,5 @@
+package com.mysugr.sweetest.framework.coroutine
+
+data class CoroutinesTestConfigurationData(
+    val useLegacyTestCoroutine: Boolean = false
+)

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
@@ -8,7 +8,18 @@ data class CoroutinesTestConfigurationData(
 
     /**
      * Default behavior is that [kotlinx.coroutines.test.setMain] is called with a CoroutineDispatcher from the test's
-     * CoroutineScope for each test. This can be disabled by setting this to false.
+     * CoroutineScope for each test. That behavior can be disabled by setting this to false.
      */
-    val autoSetMainCoroutineDispatcher: Boolean? = null
-)
+    val autoSetMainCoroutineDispatcher: Boolean? = null,
+
+    /**
+     * [kotlinx.coroutines.test.TestCoroutineScope.cleanupTestCoroutines] is called by default after each test. That
+     * behavior can be disabled by setting this to false.
+     */
+    val autoCleanupTestCoroutines: Boolean? = null
+) {
+    object Defaults {
+        val autoSetMainCoroutineDispatcher = true
+        val autoCleanupTestCoroutines = false
+    }
+}

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
@@ -16,10 +16,18 @@ data class CoroutinesTestConfigurationData(
      * [kotlinx.coroutines.test.TestCoroutineScope.cleanupTestCoroutines] is called by default after each test. That
      * behavior can be disabled by setting this to false.
      */
-    val autoCleanupTestCoroutines: Boolean? = null
+    val autoCancelTestCoroutines: Boolean? = null
 ) {
     object Defaults {
         val autoSetMainCoroutineDispatcher = true
-        val autoCleanupTestCoroutines = false
+        val autoCancelTestCoroutines = false
     }
 }
+
+val CoroutinesTestConfigurationData.autoCancelTestCoroutinesEnabled
+    get() = this.autoCancelTestCoroutines
+        ?: CoroutinesTestConfigurationData.Defaults.autoCancelTestCoroutines
+
+val CoroutinesTestConfigurationData.autoSetMainCoroutineDispatcherEnabled
+    get() = this.autoSetMainCoroutineDispatcher
+        ?: CoroutinesTestConfigurationData.Defaults.autoSetMainCoroutineDispatcher

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
@@ -13,8 +13,9 @@ data class CoroutinesTestConfigurationData(
     val autoSetMainCoroutineDispatcher: Boolean? = null,
 
     /**
-     * [kotlinx.coroutines.test.TestCoroutineScope.cleanupTestCoroutines] is called by default after each test. That
-     * behavior can be disabled by setting this to false.
+     * The [kotlinx.coroutines.Job] that runs the test can still be active in case children jobs exist that are still
+     * running. This option can be enabled to automatically close the parent job including all its children. By default
+     * this is not enabled.
      */
     val autoCancelTestCoroutines: Boolean? = null
 ) {

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
@@ -4,7 +4,7 @@ data class CoroutinesTestConfigurationData(
     /**
      * Use [LegacyCoroutinesTestContext] instead of [DefaultCoroutinesTestContext]
      */
-    val useLegacyTestCoroutine: Boolean = false,
+    val useLegacyTestCoroutine: Boolean? = null,
 
     /**
      * Default behavior is that [kotlinx.coroutines.test.setMain] is called with a CoroutineDispatcher from the test's
@@ -20,10 +20,15 @@ data class CoroutinesTestConfigurationData(
     val autoCancelTestCoroutines: Boolean? = null
 ) {
     object Defaults {
+        val useLegacyTestCoroutine = false
         val autoSetMainCoroutineDispatcher = true
         val autoCancelTestCoroutines = false
     }
 }
+
+val CoroutinesTestConfigurationData.useLegacyTestCoroutineEnabled
+    get() = this.useLegacyTestCoroutine
+        ?: CoroutinesTestConfigurationData.Defaults.useLegacyTestCoroutine
 
 val CoroutinesTestConfigurationData.autoCancelTestCoroutinesEnabled
     get() = this.autoCancelTestCoroutines

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestConfigurationData.kt
@@ -1,5 +1,14 @@
 package com.mysugr.sweetest.framework.coroutine
 
 data class CoroutinesTestConfigurationData(
-    val useLegacyTestCoroutine: Boolean = false
+    /**
+     * Use [LegacyCoroutinesTestContext] instead of [DefaultCoroutinesTestContext]
+     */
+    val useLegacyTestCoroutine: Boolean = false,
+
+    /**
+     * Default behavior is that [kotlinx.coroutines.test.setMain] is called with a CoroutineDispatcher from the test's
+     * CoroutineScope for each test. This can be disabled by setting this to false.
+     */
+    val autoSetMainCoroutineDispatcher: Boolean? = null
 )

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
@@ -1,30 +1,29 @@
 package com.mysugr.sweetest.framework.coroutine
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.cancelAndJoin
-import java.util.concurrent.Executors
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 
-/**
- * Experimental
- */
-class CoroutinesTestContext {
-    private val name = CoroutineName("testCoroutine${instanceCounter++}")
-    private val supervisorJob = SupervisorJob()
+interface CoroutinesTestContext {
+    val coroutineDispatcher get() = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
     val coroutineContext: CoroutineContext
-        get() = coroutineDispatcher + supervisorJob + name
 
-    suspend fun testFinished() {
-        supervisorJob.cancelAndJoin()
-    }
+    suspend fun finish()
 
     companion object {
-        val coroutineDispatcher: CoroutineDispatcher by lazy {
-            Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+
+        val coroutineDispatcher get() = getCurrentInstance().coroutineDispatcher
+
+        private var currentInstance: CoroutinesTestContext? = null
+
+        internal fun setCurrentInstance(coroutinesTestContext: CoroutinesTestContext?) {
+            currentInstance = coroutinesTestContext
         }
-        private var instanceCounter = 0
+
+        private fun getCurrentInstance(): CoroutinesTestContext =
+            currentInstance ?: error(
+                "CoroutinesTestContext is not set, please make sure you don't " +
+                    "access coroutineDispatcher or coroutineContext prematurely"
+            )
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.ContinuationInterceptor
 
 interface CoroutinesTestContext {
+
     val coroutineScope: CoroutineScope
 
     fun finish()
@@ -29,4 +30,3 @@ interface CoroutinesTestContext {
             )
     }
 }
-

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
@@ -8,7 +8,7 @@ interface CoroutinesTestContext {
 
     val coroutineScope: CoroutineScope
 
-    fun finish()
+    fun cleanupCoroutines()
 
     companion object {
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
@@ -2,13 +2,14 @@ package com.mysugr.sweetest.framework.coroutine
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlin.coroutines.ContinuationInterceptor
 
 interface CoroutinesTestContext {
 
     val coroutineScope: CoroutineScope
 
-    fun cleanupCoroutines()
+    fun runTest(testBody: suspend () -> Unit)
 
     companion object {
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
@@ -1,18 +1,20 @@
 package com.mysugr.sweetest.framework.coroutine
 
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.ContinuationInterceptor
-import kotlin.coroutines.CoroutineContext
 
 interface CoroutinesTestContext {
-    val coroutineDispatcher get() = coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
-    val coroutineContext: CoroutineContext
+    val coroutineScope: CoroutineScope
 
-    suspend fun finish()
+    fun finish()
 
     companion object {
 
-        val coroutineDispatcher get() = getCurrentInstance().coroutineDispatcher
+        val coroutineDispatcher
+            get() = getCurrentInstance()
+                .coroutineScope
+                .coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
 
         private var currentInstance: CoroutinesTestContext? = null
 
@@ -27,3 +29,4 @@ interface CoroutinesTestContext {
             )
     }
 }
+

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContext.kt
@@ -2,7 +2,6 @@ package com.mysugr.sweetest.framework.coroutine
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlin.coroutines.ContinuationInterceptor
 
 interface CoroutinesTestContext {
@@ -25,9 +24,6 @@ interface CoroutinesTestContext {
         }
 
         private fun getCurrentInstance(): CoroutinesTestContext =
-            currentInstance ?: error(
-                "CoroutinesTestContext is not set, please make sure you don't " +
-                    "access coroutineDispatcher or coroutineContext prematurely"
-            )
+            currentInstance ?: throw CoroutinesUninitializedException()
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
@@ -76,10 +76,7 @@ internal class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestCo
     }
 
     private fun getDelegate(): CoroutinesTestContext =
-        delegate ?: error(
-            "Coroutine support is not initialized, please use sweetest's " +
-                "runBlockingTest extension in your test class!"
-        )
+        delegate ?: throw CoroutinesUninitializedException()
 
     private fun setDelegate(coroutinesTestContext: CoroutinesTestContext?) {
         delegate = coroutinesTestContext

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
@@ -1,0 +1,43 @@
+package com.mysugr.sweetest.framework.coroutine
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.CoroutineContext
+
+class CoroutinesTestContextProvider : CoroutinesTestContext {
+
+    private var delegate: CoroutinesTestContext? = null
+
+    override val coroutineDispatcher: CoroutineDispatcher
+        get() = getDelegate().coroutineDispatcher
+
+    override val coroutineContext: CoroutineContext
+        get() = getDelegate().coroutineContext
+
+    fun initializeLegacy() {
+        checkAlreadyInitialized()
+        setDelegate(LegacyCoroutinesTestContext())
+    }
+
+    override suspend fun finish() {
+        try {
+            getDelegate().finish()
+        } finally {
+            setDelegate(null)
+        }
+    }
+
+    private fun getDelegate(): CoroutinesTestContext =
+        delegate ?: error(
+            "Coroutine support is not initialized, please use sweetest's " +
+                "runBlockingTest extension in your test class!"
+        )
+
+    private fun setDelegate(coroutinesTestContext: CoroutinesTestContext?) {
+        delegate = coroutinesTestContext
+        CoroutinesTestContext.setCurrentInstance(coroutinesTestContext)
+    }
+
+    private fun checkAlreadyInitialized() {
+        check(delegate == null) { "Already initialized" }
+    }
+}

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
@@ -1,15 +1,24 @@
 package com.mysugr.sweetest.framework.coroutine
 
+import com.mysugr.sweetest.framework.context.WorkflowTestContext
+import com.mysugr.sweetest.framework.flow.InitializationStep
 import kotlinx.coroutines.CoroutineScope
 
-class CoroutinesTestContextProvider : CoroutinesTestContext {
+class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestContext) :
+    CoroutinesTestContext {
 
     private var delegate: CoroutinesTestContext? = null
 
     override val coroutineScope: CoroutineScope
         get() = getDelegate().coroutineScope
 
-    fun initializeLegacy() {
+    init {
+        workflowTestContext.subscribe(InitializationStep.SET_UP) {
+            initializeLegacy()
+        }
+    }
+
+    private fun initializeLegacy() {
         checkAlreadyInitialized()
         setDelegate(LegacyCoroutinesTestContext())
     }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
@@ -1,17 +1,13 @@
 package com.mysugr.sweetest.framework.coroutine
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
 
 class CoroutinesTestContextProvider : CoroutinesTestContext {
 
     private var delegate: CoroutinesTestContext? = null
 
-    override val coroutineDispatcher: CoroutineDispatcher
-        get() = getDelegate().coroutineDispatcher
-
-    override val coroutineContext: CoroutineContext
-        get() = getDelegate().coroutineContext
+    override val coroutineScope: CoroutineScope
+        get() = getDelegate().coroutineScope
 
     fun initializeLegacy() {
         checkAlreadyInitialized()

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
@@ -4,17 +4,19 @@ import com.mysugr.sweetest.framework.context.WorkflowTestContext
 import com.mysugr.sweetest.framework.flow.InitializationStep
 import kotlinx.coroutines.CoroutineScope
 
-class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestContext) :
-    CoroutinesTestContext {
+class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestContext) {
 
     private var delegate: CoroutinesTestContext? = null
 
-    override val coroutineScope: CoroutineScope
+    val coroutineScope: CoroutineScope
         get() = getDelegate().coroutineScope
 
     init {
         workflowTestContext.subscribe(InitializationStep.SET_UP) {
             initializeLegacy()
+        }
+        workflowTestContext.subscribe(InitializationStep.TEAR_DOWN) {
+            finish()
         }
     }
 
@@ -23,7 +25,7 @@ class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestContext) :
         setDelegate(LegacyCoroutinesTestContext())
     }
 
-    override suspend fun finish() {
+    private fun finish() {
         try {
             getDelegate().finish()
         } finally {

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
@@ -24,7 +24,7 @@ internal class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestCo
         finishOnTearDownEvent(workflowTestContext)
     }
 
-    fun configure(block: CoroutinesTestConfiguration.() -> Unit) {
+    fun configure(block: CoroutinesTestConfigurator.() -> Unit) {
         checkAlreadyInitialized()
         block(configuration)
     }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextProvider.kt
@@ -16,8 +16,14 @@ internal class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestCo
 
     private var delegate: CoroutinesTestContext? = null
     private val isInitialized get() = delegate != null
+
     private val configuration = CoroutinesTestConfiguration()
-    private val autoSetMainCoroutineDispatcherEnabled get() = configuration.data.autoSetMainCoroutineDispatcher ?: true
+    private val autoSetMainCoroutineDispatcherEnabled
+        get() = configuration.data.autoSetMainCoroutineDispatcher
+            ?: CoroutinesTestConfigurationData.Defaults.autoSetMainCoroutineDispatcher
+    private val autoCleanupTestCoroutinesEnabled
+        get() = configuration.data.autoCleanupTestCoroutines
+            ?: CoroutinesTestConfigurationData.Defaults.autoCleanupTestCoroutines
 
     init {
         initializeOnSetUpEvent(workflowTestContext)
@@ -53,7 +59,9 @@ internal class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestCo
 
     private fun finish() {
         try {
-            getDelegate().finish()
+            if (autoCleanupTestCoroutinesEnabled) {
+                getDelegate().cleanupCoroutines()
+            }
         } finally {
             setDelegate(null)
             autoResetMainCoroutineDispatcher()

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
@@ -46,7 +46,7 @@ internal class CoroutinesTestContextWrapper(private val workflowTestContext: Wor
 
     private fun initialize() {
         checkAlreadyInitialized()
-        if (configuration.data.useLegacyTestCoroutine) {
+        if (configuration.data.useLegacyTestCoroutineEnabled) {
             setDelegate(LegacyCoroutinesTestContext(configuration.data))
         } else {
             setDelegate(DefaultCoroutinesTestContext(configuration.data))

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
@@ -47,7 +47,11 @@ internal class CoroutinesTestContextWrapper(private val workflowTestContext: Wor
     private fun initialize() {
         checkAlreadyInitialized()
         if (configuration.data.useLegacyTestCoroutineEnabled) {
-            setDelegate(LegacyCoroutinesTestContext(configuration.data))
+            setDelegate(
+                LegacyCoroutinesTestContext(
+                    configuration.data
+                )
+            )
         } else {
             setDelegate(DefaultCoroutinesTestContext(configuration.data))
         }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
@@ -9,10 +9,9 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import kotlin.coroutines.ContinuationInterceptor
 
-internal class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestContext) {
+internal class CoroutinesTestContextWrapper(workflowTestContext: WorkflowTestContext): CoroutinesTestContext {
 
-    val coroutineScope: CoroutineScope
-        get() = getDelegate().coroutineScope
+    override val coroutineScope: CoroutineScope get() = getDelegate().coroutineScope
 
     private var delegate: CoroutinesTestContext? = null
     private val isInitialized get() = delegate != null
@@ -29,7 +28,7 @@ internal class CoroutinesTestContextProvider(workflowTestContext: WorkflowTestCo
         block(configuration)
     }
 
-    fun runTest(testBody: suspend () -> Unit) {
+    override fun runTest(testBody: suspend () -> Unit) {
         getDelegate().runTest(testBody)
     }
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import kotlin.coroutines.ContinuationInterceptor
 
-internal class CoroutinesTestContextWrapper(workflowTestContext: WorkflowTestContext) : CoroutinesTestContext {
+internal class CoroutinesTestContextWrapper(private val workflowTestContext: WorkflowTestContext) : CoroutinesTestContext {
 
     override val coroutineScope: CoroutineScope get() = getDelegate().coroutineScope
 
@@ -19,8 +19,8 @@ internal class CoroutinesTestContextWrapper(workflowTestContext: WorkflowTestCon
     private val configuration = CoroutinesTestConfiguration()
 
     init {
-        initializeOnSetUpEvent(workflowTestContext)
-        finishOnTearDownEvent(workflowTestContext)
+        initializeOnInitializeFrameworkEvent()
+        finishOnTearDownEvent()
     }
 
     fun configure(block: CoroutinesTestConfigurator.() -> Unit) {
@@ -32,13 +32,13 @@ internal class CoroutinesTestContextWrapper(workflowTestContext: WorkflowTestCon
         getDelegate().runTest(testBody)
     }
 
-    private fun initializeOnSetUpEvent(workflowTestContext: WorkflowTestContext) {
-        workflowTestContext.subscribe(InitializationStep.SET_UP) {
+    private fun initializeOnInitializeFrameworkEvent() {
+        workflowTestContext.subscribe(InitializationStep.INITIALIZE_FRAMEWORK) {
             this.initialize()
         }
     }
 
-    private fun finishOnTearDownEvent(workflowTestContext: WorkflowTestContext) {
+    private fun finishOnTearDownEvent() {
         workflowTestContext.subscribe(InitializationStep.TEAR_DOWN) {
             finish()
         }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesTestContextWrapper.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import kotlin.coroutines.ContinuationInterceptor
 
-internal class CoroutinesTestContextWrapper(workflowTestContext: WorkflowTestContext): CoroutinesTestContext {
+internal class CoroutinesTestContextWrapper(workflowTestContext: WorkflowTestContext) : CoroutinesTestContext {
 
     override val coroutineScope: CoroutineScope get() = getDelegate().coroutineScope
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesUninitializedException.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesUninitializedException.kt
@@ -1,7 +1,6 @@
 package com.mysugr.sweetest.framework.coroutine
 
 class CoroutinesUninitializedException : Exception(
-    "sweetest's coroutines capabilities are used outside its valid timeframe! Please prevent using them before or " +
-        "after the test function is run. Don't access them in constructors, class or property initializers, but " +
-        "consider using `lazy { ... }` or do initialization in `.onSetUp { ... }` instead."
+    "sweetest's coroutines capabilities are used in a wrong place! " +
+        "Please prevent using them after the test function is run."
 )

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesUninitializedException.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/CoroutinesUninitializedException.kt
@@ -1,0 +1,7 @@
+package com.mysugr.sweetest.framework.coroutine
+
+class CoroutinesUninitializedException : Exception(
+    "sweetest's coroutines capabilities are used outside its valid timeframe! Please prevent using them before or " +
+        "after the test function is run. Don't access them in constructors, class or property initializers, but " +
+        "consider using `lazy { ... }` or do initialization in `.onSetUp { ... }` instead."
+)

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
@@ -15,7 +15,7 @@ class DefaultCoroutinesTestContext(
 
     override val coroutineScope = TestCoroutineScope(coroutineContext)
 
-    override fun finish() {
+    override fun cleanupCoroutines() {
         // runBlockingTest/Sweetest handles finishing, don't need to do anything here
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
@@ -1,5 +1,6 @@
 package com.mysugr.sweetest.framework.coroutine
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -11,7 +12,7 @@ import kotlinx.coroutines.test.UncompletedCoroutinesError
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 
-class DefaultCoroutinesTestContext(private val configuration: CoroutinesTestConfigurationData) : CoroutinesTestContext {
+internal class DefaultCoroutinesTestContext(private val configuration: CoroutinesTestConfigurationData) : CoroutinesTestContext {
 
     val job = SupervisorJob()
     override val coroutineScope = TestCoroutineScope(job)

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
@@ -1,21 +1,74 @@
 package com.mysugr.sweetest.framework.coroutine
 
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.DelayController
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineExceptionHandler
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.UncaughtExceptionCaptor
+import kotlinx.coroutines.test.UncompletedCoroutinesError
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 class DefaultCoroutinesTestContext(
+    private val configuration: CoroutinesTestConfigurationData,
     /**
-     * An optional context that MAY provide [UncaughtExceptionCaptor] and/or [DelayController] for the TestCoroutineScope
+     * An optional context that MAY provide [UncaughtExceptionCaptor] and/or [DelayController] for the
+     * TestCoroutineScope
      */
     coroutineContext: CoroutineContext = EmptyCoroutineContext
 ) : CoroutinesTestContext {
 
-    override val coroutineScope = TestCoroutineScope(coroutineContext)
+    override val coroutineScope = TestCoroutineScope(coroutineContext.checkArguments())
 
-    override fun cleanupCoroutines() {
-        // runBlockingTest/Sweetest handles finishing, don't need to do anything here
+    override fun runTest(testBody: suspend () -> Unit) {
+        val parentJob = checkNotNull(coroutineScope.coroutineContext[Job])
+        val dispatcher = checkNotNull(coroutineScope.coroutineContext[ContinuationInterceptor] as? DelayController)
+
+        val startingJobs = parentJob.activeJobs()
+        val deferred = coroutineScope.async {
+            testBody()
+        }
+        dispatcher.advanceUntilIdle()
+        deferred.getCompletionExceptionOrNull()?.let {
+            throw it
+        }
+        if (configuration.autoCancelTestCoroutinesEnabled) {
+            runBlocking {
+                parentJob.cancelAndJoin()
+            }
+        }
+        coroutineScope.cleanupTestCoroutines()
+        val endingJobs = parentJob.activeJobs()
+        if ((endingJobs - startingJobs).isNotEmpty()) {
+            throw UncompletedCoroutinesError("Test finished with active jobs: $endingJobs")
+        }
     }
+}
+
+private fun CoroutineContext.checkArguments(): CoroutineContext {
+    val dispatcher = get(ContinuationInterceptor).run {
+        this?.let { require(this is DelayController) { "Dispatcher must implement DelayController: $this" } }
+        this ?: TestCoroutineDispatcher()
+    }
+
+    val exceptionHandler = get(CoroutineExceptionHandler).run {
+        this?.let {
+            require(this is UncaughtExceptionCaptor) { "coroutineExceptionHandler must implement UncaughtExceptionCaptor: $this" }
+        }
+        this ?: TestCoroutineExceptionHandler()
+    }
+
+    val job = get(Job) ?: SupervisorJob()
+    return this + dispatcher + exceptionHandler + job
+}
+
+private fun CoroutineContext.activeJobs(): Set<Job> {
+    return checkNotNull(this[Job]).children.filter { it.isActive }.toSet()
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
@@ -1,6 +1,5 @@
 package com.mysugr.sweetest.framework.coroutine
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
@@ -1,37 +1,25 @@
 package com.mysugr.sweetest.framework.coroutine
 
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.DelayController
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineExceptionHandler
 import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.UncaughtExceptionCaptor
 import kotlinx.coroutines.test.UncompletedCoroutinesError
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 
-class DefaultCoroutinesTestContext(
-    private val configuration: CoroutinesTestConfigurationData,
-    /**
-     * An optional context that MAY provide [UncaughtExceptionCaptor] and/or [DelayController] for the
-     * TestCoroutineScope
-     */
-    coroutineContext: CoroutineContext = EmptyCoroutineContext
-) : CoroutinesTestContext {
+class DefaultCoroutinesTestContext(private val configuration: CoroutinesTestConfigurationData) : CoroutinesTestContext {
 
-    override val coroutineScope = TestCoroutineScope(coroutineContext.checkArguments())
+    val job = SupervisorJob()
+    override val coroutineScope = TestCoroutineScope(job)
 
     override fun runTest(testBody: suspend () -> Unit) {
-        val parentJob = checkNotNull(coroutineScope.coroutineContext[Job])
         val dispatcher = checkNotNull(coroutineScope.coroutineContext[ContinuationInterceptor] as? DelayController)
 
-        val startingJobs = parentJob.activeJobs()
+        val startingJobs = job.activeJobs()
         val deferred = coroutineScope.async {
             testBody()
         }
@@ -41,32 +29,15 @@ class DefaultCoroutinesTestContext(
         }
         if (configuration.autoCancelTestCoroutinesEnabled) {
             runBlocking {
-                parentJob.cancelAndJoin()
+                job.cancelAndJoin()
             }
         }
         coroutineScope.cleanupTestCoroutines()
-        val endingJobs = parentJob.activeJobs()
+        val endingJobs = job.activeJobs()
         if ((endingJobs - startingJobs).isNotEmpty()) {
             throw UncompletedCoroutinesError("Test finished with active jobs: $endingJobs")
         }
     }
-}
-
-private fun CoroutineContext.checkArguments(): CoroutineContext {
-    val dispatcher = get(ContinuationInterceptor).run {
-        this?.let { require(this is DelayController) { "Dispatcher must implement DelayController: $this" } }
-        this ?: TestCoroutineDispatcher()
-    }
-
-    val exceptionHandler = get(CoroutineExceptionHandler).run {
-        this?.let {
-            require(this is UncaughtExceptionCaptor) { "coroutineExceptionHandler must implement UncaughtExceptionCaptor: $this" }
-        }
-        this ?: TestCoroutineExceptionHandler()
-    }
-
-    val job = get(Job) ?: SupervisorJob()
-    return this + dispatcher + exceptionHandler + job
 }
 
 private fun CoroutineContext.activeJobs(): Set<Job> {

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/DefaultCoroutinesTestContext.kt
@@ -1,0 +1,21 @@
+package com.mysugr.sweetest.framework.coroutine
+
+import kotlinx.coroutines.test.DelayController
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.UncaughtExceptionCaptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+class DefaultCoroutinesTestContext(
+    /**
+     * An optional context that MAY provide [UncaughtExceptionCaptor] and/or [DelayController] for the TestCoroutineScope
+     */
+    coroutineContext: CoroutineContext = EmptyCoroutineContext
+) : CoroutinesTestContext {
+
+    override val coroutineScope = TestCoroutineScope(coroutineContext)
+
+    override fun finish() {
+        // runBlockingTest/Sweetest handles finishing, don't need to do anything here
+    }
+}

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
@@ -1,0 +1,23 @@
+package com.mysugr.sweetest.framework.coroutine
+
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.Executors
+
+class LegacyCoroutinesTestContext : CoroutinesTestContext {
+    private val name = CoroutineName("testCoroutine${instanceCounter++}")
+    private val supervisorJob = SupervisorJob()
+    override val coroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    override val coroutineContext = coroutineDispatcher + supervisorJob + name
+
+    override suspend fun finish() = runBlocking {
+        supervisorJob.cancelAndJoin()
+    }
+
+    companion object {
+        private var instanceCounter = 0
+    }
+}

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
@@ -1,6 +1,7 @@
 package com.mysugr.sweetest.framework.coroutine
 
 import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelAndJoin
@@ -10,10 +11,11 @@ import java.util.concurrent.Executors
 class LegacyCoroutinesTestContext : CoroutinesTestContext {
     private val name = CoroutineName("testCoroutine${instanceCounter++}")
     private val supervisorJob = SupervisorJob()
-    override val coroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-    override val coroutineContext = coroutineDispatcher + supervisorJob + name
+    private val coroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
 
-    override suspend fun finish() = runBlocking {
+    override val coroutineScope = CoroutineScope(coroutineDispatcher + supervisorJob + name)
+
+    override fun finish() = runBlocking {
         supervisorJob.cancelAndJoin()
     }
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.util.concurrent.Executors
 
-class LegacyCoroutinesTestContext(
+internal class LegacyCoroutinesTestContext(
     private val configuration: CoroutinesTestConfigurationData
 ) : CoroutinesTestContext {
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
@@ -15,7 +15,7 @@ class LegacyCoroutinesTestContext : CoroutinesTestContext {
 
     override val coroutineScope = CoroutineScope(coroutineDispatcher + supervisorJob + name)
 
-    override fun finish() = runBlocking {
+    override fun cleanupCoroutines() = runBlocking {
         supervisorJob.cancelAndJoin()
     }
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -14,13 +14,8 @@ fun BaseJUnitTest.testCoroutine(
     testBlock: suspend CoroutineScope.() -> Unit
 ) {
     runBlocking {
-        val coroutinesTestContext = accessor.testContext.coroutines
-        try {
-            withContext(coroutinesTestContext.coroutineContext) {
-                testBlock()
-            }
-        } finally {
-            coroutinesTestContext.finish()
+        withContext(accessor.testContext.coroutines.coroutineScope.coroutineContext) {
+            testBlock()
         }
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -15,7 +15,6 @@ fun BaseJUnitTest.testCoroutine(
 ) {
     runBlocking {
         val coroutinesTestContext = accessor.testContext.coroutines
-        coroutinesTestContext.initializeLegacy()
         try {
             withContext(coroutinesTestContext.coroutineContext) {
                 testBlock()

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -44,7 +44,9 @@ fun BaseJUnitTest.runBlockingSweetest(
 val TestingAccessor.coroutineScope get() = accessor.testContext.coroutines.coroutineScope
 
 @Suppress("EXPERIMENTAL_API_USAGE")
-val TestingAccessor.testCoroutineScope get() = accessor.testContext.coroutines.coroutineScope as TestCoroutineScope
+val TestingAccessor.testCoroutineScope
+    get() = accessor.testContext.coroutines.coroutineScope as? TestCoroutineScope
+        ?: error("You are using the legacy CoroutineScope in this test, therefore `testCoroutineScope` can't be used.")
 
 suspend operator fun <T : Steps> T.invoke(run: suspend T.() -> Unit) = run(this)
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 
@@ -21,6 +22,8 @@ fun BaseJUnitTest.testCoroutine(
 }
 
 val TestingAccessor.coroutineScope get() = accessor.testContext.coroutines.coroutineScope
+
+val TestingAccessor.testCoroutineScope get() = accessor.testContext.coroutines.coroutineScope as TestCoroutineScope
 
 suspend operator fun <T : Steps> T.invoke(run: suspend T.() -> Unit) = run(this)
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -6,13 +6,8 @@ import com.mysugr.sweetest.framework.base.TestingAccessor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.DelayController
 import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
-import kotlin.coroutines.ContinuationInterceptor
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @Deprecated("Please migrate to `runBlockingSweetest`")

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import kotlin.coroutines.ContinuationInterceptor
 
+@Suppress("EXPERIMENTAL_API_USAGE")
 @Deprecated("Please migrate to `runBlockingSweetest`")
 fun BaseJUnitTest.testCoroutine(
     testBody: suspend CoroutineScope.() -> Unit
@@ -31,6 +32,7 @@ fun BaseJUnitTest.testCoroutine(
 /**
  * Wrapper around [kotlinx.coroutines.test.runBlockingTest] that takes the [TestCoroutineScope] provided by sweetest
  */
+@Suppress("EXPERIMENTAL_API_USAGE")
 fun BaseJUnitTest.runBlockingSweetest(
     testBody: suspend CoroutineScope.() -> Unit
 ) {
@@ -46,6 +48,7 @@ fun BaseJUnitTest.runBlockingSweetest(
 
 val TestingAccessor.coroutineScope get() = accessor.testContext.coroutines.coroutineScope
 
+@Suppress("EXPERIMENTAL_API_USAGE")
 val TestingAccessor.testCoroutineScope get() = accessor.testContext.coroutines.coroutineScope as TestCoroutineScope
 
 suspend operator fun <T : Steps> T.invoke(run: suspend T.() -> Unit) = run(this)
@@ -60,9 +63,10 @@ suspend fun Deferred<*>.throwExceptionIfFailed() {
  * With multiple child jobs, you may want to yield multiple times to ensure each child can finish.
  * This function counts the number of child jobs and calls [yield] the number of times as jobs are present.
  */
+@Suppress("SuspendFunctionOnCoroutineScope")
 suspend fun CoroutineScope.yieldForEachJob() {
     val job =
-        coroutineContext[Job.Key] ?: error(
+        this.coroutineContext[Job.Key] ?: error(
             "coroutineContext doesn't have a parent Job. Probably you are mistakenly using a TestCoroutineScope " +
                 "(these don't have a `Job` by default) or you don't use sweetest's legacy CoroutineScope. Pleas bear " +
                 "in mind that with runBlockingTest/Sweetest and TestCoroutineScope you don't need `yield` usually!"

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -9,18 +9,19 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 
-/**
- * Experimental
- */
 fun BaseJUnitTest.testCoroutine(
     testBlock: suspend CoroutineScope.() -> Unit
 ) {
     runBlocking {
         val coroutinesTestContext = accessor.testContext.coroutines
-        withContext(coroutinesTestContext.coroutineContext) {
-            testBlock()
+        coroutinesTestContext.initializeLegacy()
+        try {
+            withContext(coroutinesTestContext.coroutineContext) {
+                testBlock()
+            }
+        } finally {
+            coroutinesTestContext.finish()
         }
-        coroutinesTestContext.testFinished()
     }
 }
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -2,6 +2,7 @@ package com.mysugr.sweetest.framework.coroutine
 
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
 import com.mysugr.sweetest.framework.base.Steps
+import com.mysugr.sweetest.framework.base.TestingAccessor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
@@ -24,6 +25,8 @@ fun BaseJUnitTest.testCoroutine(
         }
     }
 }
+
+val TestingAccessor.coroutineScope get() = accessor.testContext.coroutines.coroutineScope
 
 suspend operator fun <T : Steps> T.invoke(run: suspend T.() -> Unit) = run(this)
 

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/VerifyOrder.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/VerifyOrder.kt
@@ -40,11 +40,11 @@ suspend fun verifyOrder(block: suspend OrderVerifier.() -> Unit) {
 class OrderVerifier {
     private var currentOrderIndex = 0
 
-    fun order(orderIndex: Int) {
+    fun order(expectedIndex: Int) {
         currentOrderIndex++
 
-        if (orderIndex != currentOrderIndex) {
-            fail("Expected order($currentOrderIndex), but reached order($orderIndex) instead")
+        if (expectedIndex != currentOrderIndex) {
+            fail("Expected order ($expectedIndex), but ($currentOrderIndex) reached instead")
         }
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/legacy/LegacyCoroutinesExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/legacy/LegacyCoroutinesExtensions.kt
@@ -5,7 +5,9 @@ import com.mysugr.sweetest.framework.base.TestingAccessor
 import com.mysugr.sweetest.framework.coroutine.delayController
 import com.mysugr.sweetest.framework.coroutine.uncaughtExceptionCaptor
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.yield
 
 /**
  * Imitates [kotlinx.coroutines.test.runBlockingTest] and uses the [TestCoroutineScope] provided by sweetest. You can
@@ -24,3 +26,21 @@ fun BaseJUnitTest.testCoroutine(
 }
 
 val TestingAccessor.coroutineScope get() = accessor.testContext.coroutines.coroutineScope
+
+/**
+ * With multiple child jobs, you may want to yield multiple times to ensure each child can finish.
+ * This function counts the number of child jobs and calls [yield] the number of times as jobs are present.
+ */
+@Suppress("SuspendFunctionOnCoroutineScope")
+@Deprecated("Not needed for tests with TestCoroutineScope anymore")
+suspend fun CoroutineScope.yieldForEachJob() {
+    val job =
+        this.coroutineContext[Job.Key] ?: error(
+            "coroutineContext doesn't have a parent Job. Probably you are mistakenly using a TestCoroutineScope " +
+                "(these don't have a `Job` by default) or you don't use sweetest's legacy CoroutineScope. Pleas bear " +
+                "in mind that with runBlockingTest/Sweetest and TestCoroutineScope you don't need `yield` usually!"
+        )
+    kotlin.repeat(countJobs(job)) { yield() }
+}
+
+private fun countJobs(job: Job): Int = 1 + job.children.sumBy { countJobs(it) }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/legacy/LegacyCoroutinesExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/legacy/LegacyCoroutinesExtensions.kt
@@ -1,0 +1,26 @@
+package com.mysugr.sweetest.framework.coroutine.legacy
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.base.TestingAccessor
+import com.mysugr.sweetest.framework.coroutine.delayController
+import com.mysugr.sweetest.framework.coroutine.uncaughtExceptionCaptor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestCoroutineScope
+
+/**
+ * Imitates [kotlinx.coroutines.test.runBlockingTest] and uses the [TestCoroutineScope] provided by sweetest. You can
+ * access [TestCoroutineScope] features via [coroutineScope], [delayController] and [uncaughtExceptionCaptor]
+ *
+ * There is a legacy mode that works with the previous sweetest solution (can be enabled by calling
+ * `useLegacyCoroutineScope` on the configuration).
+ */
+@Suppress("EXPERIMENTAL_API_USAGE")
+fun BaseJUnitTest.testCoroutine(
+    testBody: suspend CoroutineScope.() -> Unit
+) {
+    accessor.testContext.coroutines.runTest {
+        testBody(coroutineScope)
+    }
+}
+
+val TestingAccessor.coroutineScope get() = accessor.testContext.coroutines.coroutineScope

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/legacy/LegacyCoroutinesExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/legacy/LegacyCoroutinesExtensions.kt
@@ -17,6 +17,10 @@ import kotlinx.coroutines.yield
  * `useLegacyCoroutineScope` on the configuration).
  */
 @Suppress("EXPERIMENTAL_API_USAGE")
+@Deprecated(
+    "The old way of testing coroutines is deprecated. Please use the new `testCoroutine` which wraps uses " +
+        "coroutine's original TestCoroutineScope and runBlockingtest."
+)
 fun BaseJUnitTest.testCoroutine(
     testBody: suspend CoroutineScope.() -> Unit
 ) {
@@ -32,7 +36,7 @@ val TestingAccessor.coroutineScope get() = accessor.testContext.coroutines.corou
  * This function counts the number of child jobs and calls [yield] the number of times as jobs are present.
  */
 @Suppress("SuspendFunctionOnCoroutineScope")
-@Deprecated("Not needed for tests with TestCoroutineScope anymore")
+@Deprecated("Not needed for tests with TestCoroutineScope anymore, please migrate your tests and disable legacy mode.")
 suspend fun CoroutineScope.yieldForEachJob() {
     val job =
         this.coroutineContext[Job.Key] ?: error(

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/flow/InitializationStep.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/flow/InitializationStep.kt
@@ -5,7 +5,9 @@ enum class InitializationStep(val order: Int) {
     INITIALIZE_STEPS(1),
     INITIALIZE_DEPENDENCIES(2),
     SET_UP(3),
-    DONE(4);
+    RUNNING(4),
+    TEAR_DOWN(5),
+    DONE(6);
 
     fun isBeforeOrSame(other: InitializationStep) = other.order >= order
     fun isBefore(other: InitializationStep) = other.order > order

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/flow/InitializationStep.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/flow/InitializationStep.kt
@@ -1,18 +1,19 @@
 package com.mysugr.sweetest.framework.flow
 
-enum class InitializationStep(val order: Int) {
-    INITIALIZE_FRAMEWORK(0),
-    INITIALIZE_STEPS(1),
-    INITIALIZE_DEPENDENCIES(2),
-    SET_UP(3),
-    RUNNING(4),
-    TEAR_DOWN(5),
-    DONE(6);
+enum class InitializationStep {
+    UNINITIALIZED,
+    INITIALIZE_FRAMEWORK,
+    INITIALIZE_STEPS,
+    INITIALIZE_DEPENDENCIES,
+    SET_UP,
+    RUNNING,
+    TEAR_DOWN,
+    DONE;
 
-    fun isBeforeOrSame(other: InitializationStep) = other.order >= order
-    fun isBefore(other: InitializationStep) = other.order > order
-    fun isAfter(other: InitializationStep) = other.order < order
-    fun isAfterOrSame(other: InitializationStep) = other.order <= order
+    fun isBeforeOrSame(other: InitializationStep) = other.ordinal >= ordinal
+    fun isBefore(other: InitializationStep) = other.ordinal > ordinal
+    fun isAfter(other: InitializationStep) = other.ordinal < ordinal
+    fun isAfterOrSame(other: InitializationStep) = other.ordinal <= ordinal
 
-    fun getNext() = values()[order + 1]
+    fun getNext() = values()[ordinal + 1]
 }

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoCancelTestCoroutinesConfigurationTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoCancelTestCoroutinesConfigurationTest.kt
@@ -1,0 +1,41 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.coroutine.CoroutinesTestConfiguration
+import com.mysugr.sweetest.framework.coroutine.autoCancelTestCoroutinesEnabled
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoCancelTestCoroutinesConfigurationTest {
+
+    private val sut = CoroutinesTestConfiguration()
+
+    @Test
+    fun `autoCancelTestCoroutines is false by default`() {
+        assertFalse(sut.data.autoCancelTestCoroutinesEnabled)
+    }
+
+    @Test
+    fun `autoCancelTestCoroutines is set to true`() {
+        sut.autoCancelTestCoroutines(true)
+        assertTrue(sut.data.autoCancelTestCoroutinesEnabled)
+    }
+
+    @Test
+    fun `autoCancelTestCoroutines is set to false`() {
+        sut.autoCancelTestCoroutines(false)
+        assertFalse(sut.data.autoCancelTestCoroutinesEnabled)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `autoCancelTestCoroutines can't be changed from true to false`() {
+        sut.autoCancelTestCoroutines(true)
+        sut.autoCancelTestCoroutines(false)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `autoCancelTestCoroutines can't be changed from false to true`() {
+        sut.autoCancelTestCoroutines(false)
+        sut.autoCancelTestCoroutines(true)
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoCancelTestCoroutinesDisabledTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoCancelTestCoroutinesDisabledTest.kt
@@ -1,0 +1,23 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.test.UncompletedCoroutinesError
+import org.junit.Test
+
+class AutoCancelTestCoroutinesDisabledTest : BaseJUnitTest(moduleTestingConfiguration()) {
+
+    override fun configure() = super.configure()
+        .autoCancelTestCoroutines(false)
+
+    @Test(expected = UncompletedCoroutinesError::class)
+    fun `There will be a complaint about jobs still being active`() = testCoroutine {
+        BroadcastChannel<Int>(1)
+            .asFlow()
+            .launchIn(this)
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoCancelTestCoroutinesEnabledTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoCancelTestCoroutinesEnabledTest.kt
@@ -1,0 +1,22 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.launchIn
+import org.junit.Test
+
+class AutoCancelTestCoroutinesEnabledTest : BaseJUnitTest(moduleTestingConfiguration()) {
+
+    override fun configure() = super.configure()
+        .autoCancelTestCoroutines(true)
+
+    @Test
+    fun `There is no complaint about jobs still being active`() = testCoroutine {
+        BroadcastChannel<Int>(1)
+            .asFlow()
+            .launchIn(this)
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoSetMainDispatcherConfigurationTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoSetMainDispatcherConfigurationTest.kt
@@ -1,0 +1,41 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.coroutine.CoroutinesTestConfiguration
+import com.mysugr.sweetest.framework.coroutine.autoSetMainCoroutineDispatcherEnabled
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoSetMainDispatcherConfigurationTest {
+
+    private val sut = CoroutinesTestConfiguration()
+
+    @Test
+    fun `autoSetMainCoroutineDispatcher is true by default`() {
+        assertTrue(sut.data.autoSetMainCoroutineDispatcherEnabled)
+    }
+
+    @Test
+    fun `autoSetMainCoroutineDispatcher is set to true`() {
+        sut.autoSetMainCoroutineDispatcher(true)
+        assertTrue(sut.data.autoSetMainCoroutineDispatcherEnabled)
+    }
+
+    @Test
+    fun `autoSetMainCoroutineDispatcher is set to false`() {
+        sut.autoSetMainCoroutineDispatcher(false)
+        assertFalse(sut.data.autoSetMainCoroutineDispatcherEnabled)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `autoSetMainCoroutineDispatcher can't be changed from true to false`() {
+        sut.autoSetMainCoroutineDispatcher(true)
+        sut.autoSetMainCoroutineDispatcher(false)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `autoSetMainCoroutineDispatcher can't be changed from false to true`() {
+        sut.autoSetMainCoroutineDispatcher(false)
+        sut.autoSetMainCoroutineDispatcher(true)
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoSetMainDispatcherDisabledTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoSetMainDispatcherDisabledTest.kt
@@ -1,0 +1,19 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.junit.Test
+
+class AutoSetMainDispatcherDisabledTest : BaseJUnitTest(moduleTestingConfiguration()) {
+
+    override fun configure() = super.configure()
+        .autoSetMainCoroutineDispatcher(false)
+
+    @Test(expected = IllegalStateException::class)
+    fun `Main dispatcher is not set`() = testCoroutine {
+        withContext(Dispatchers.Main) { }
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoSetMainDispatcherEnabledTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/AutoSetMainDispatcherEnabledTest.kt
@@ -1,0 +1,18 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
+import kotlinx.coroutines.Dispatchers
+import org.junit.Test
+
+class AutoSetMainDispatcherEnabledTest : BaseJUnitTest(moduleTestingConfiguration()) {
+
+    override fun configure() = super.configure()
+        .autoSetMainCoroutineDispatcher(true)
+
+    @Test
+    fun `Main dispatcher is set`() = testCoroutine {
+        Dispatchers.Main // no exception thrown
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/CoroutinesTestContextWrapperTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/CoroutinesTestContextWrapperTest.kt
@@ -1,0 +1,97 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.build.TestBuilder
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import com.mysugr.sweetest.framework.coroutine.CoroutinesTestContext
+import com.mysugr.sweetest.framework.coroutine.CoroutinesUninitializedException
+import com.mysugr.sweetest.framework.flow.InitializationStep
+import org.junit.Test
+
+class CoroutinesTestContextWrapperTest {
+
+    private val testBuilder = TestBuilder(moduleTestingConfiguration())
+
+    // --- accessing coroutine scope
+
+    @Test(expected = CoroutinesUninitializedException::class)
+    fun `Coroutine scope is not initialized before framework initialization`() {
+        try {
+            testBuilder.build()
+            getCoroutineScope() // should throw
+        } finally {
+            proceedToEnd()
+        }
+    }
+
+    @Test
+    fun `Coroutine scope is initialized at framework initialization`() {
+        try {
+            testBuilder.build()
+            proceedToFrameworkInitialization()
+            getCoroutineScope() // should not throw
+        } finally {
+            proceedToEnd()
+        }
+    }
+
+    @Test(expected = CoroutinesUninitializedException::class)
+    fun `Coroutine scope is not available after the test workflow`() {
+        testBuilder.build()
+        proceedToEnd()
+        getCoroutineScope() // throws
+    }
+
+    // --- accessing CoroutinesTestContext.coroutineDispatcher
+
+    @Test(expected = CoroutinesUninitializedException::class)
+    fun `CoroutinesTestContext is not initialized before framework initialization`() {
+        try {
+            testBuilder.build()
+            CoroutinesTestContext.coroutineDispatcher // should throw
+        } finally {
+            proceedToEnd()
+        }
+    }
+
+    @Test(expected = CoroutinesUninitializedException::class)
+    fun `CoroutinesTestContext is not available after the test workflow`() {
+        testBuilder.build()
+        proceedToEnd()
+        CoroutinesTestContext.coroutineDispatcher // should throw
+    }
+
+    // --- configuration
+
+    @Test()
+    fun `Can configure before initialization`() {
+        testBuilder.build()
+
+        accessConfiguration()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `Can't configure after initialization`() {
+        testBuilder.build()
+        testBuilder.testContext.workflow.proceedTo(InitializationStep.INITIALIZE_FRAMEWORK)
+
+        accessConfiguration() // should throw
+    }
+
+    // ---
+
+    private fun proceedToFrameworkInitialization() {
+        testBuilder.testContext.workflow.proceedTo(InitializationStep.INITIALIZE_FRAMEWORK)
+    }
+
+    private fun proceedToEnd() {
+        testBuilder.testContext.workflow.finish()
+    }
+
+    private fun accessConfiguration() {
+        testBuilder.testContext.coroutines.configure { }
+    }
+
+    private fun getCoroutineScope() {
+        testBuilder.testContext.coroutines.coroutineScope
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/FlowTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/FlowTest.kt
@@ -2,8 +2,8 @@ package com.mysugr.sweetest.coroutine
 
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
 import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
-import com.mysugr.sweetest.framework.coroutine.runBlockingSweetest
-import com.mysugr.sweetest.framework.coroutine.testCoroutineScope
+import com.mysugr.sweetest.framework.coroutine.coroutineScope
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BroadcastChannel
@@ -25,20 +25,20 @@ class FlowTest : BaseJUnitTest(moduleTestingConfiguration()) {
 
         channel.asFlow()
             .onEach { emissions.add(it) }
-            .launchIn(testCoroutineScope)
+            .launchIn(coroutineScope)
         channel.offer(1)
 
         assertEquals(1, emissions.size)
     }
 
     @Test(expected = UncompletedCoroutinesError::class)
-    fun `Hot Flow produces error when not finished`() = runBlockingSweetest {
+    fun `Hot Flow produces error when not finished`() = testCoroutine {
         val channel = BroadcastChannel<Int>(1)
         val emissions = mutableListOf<Int>()
 
         channel.asFlow()
             .onEach { emissions.add(it) }
-            .launchIn(testCoroutineScope)
+            .launchIn(coroutineScope)
 
         channel.offer(1)
         assertEquals(1, emissions.size)

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/FlowTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/FlowTest.kt
@@ -1,7 +1,7 @@
-package com.mysugr.android.testing.example.coroutine
+package com.mysugr.sweetest.coroutine
 
-import com.mysugr.android.testing.example.appModuleTestingConfiguration
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
 import com.mysugr.sweetest.framework.coroutine.runBlockingSweetest
 import com.mysugr.sweetest.framework.coroutine.testCoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,16 +10,29 @@ import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.UncompletedCoroutinesError
 import org.junit.Assert.assertEquals
+import org.junit.Test
 
 @ExperimentalCoroutinesApi
 @FlowPreview
-class FlowTestWithAutoCancel : BaseJUnitTest(appModuleTestingConfiguration) {
+class FlowTest : BaseJUnitTest(moduleTestingConfiguration()) {
 
-    override fun configure() = super.configure()
-        .autoCancelTestCoroutines(true) // <-- !
+    @Test
+    fun `Hot Flow with TestCoroutineScope is successful`() {
+        val channel = BroadcastChannel<Int>(1)
+        val emissions = mutableListOf<Int>()
 
-    fun `In contrast to FlowTest without auto cancel, here no exception is expected`() = runBlockingSweetest {
+        channel.asFlow()
+            .onEach { emissions.add(it) }
+            .launchIn(testCoroutineScope)
+        channel.offer(1)
+
+        assertEquals(1, emissions.size)
+    }
+
+    @Test(expected = UncompletedCoroutinesError::class)
+    fun `Hot Flow produces error when not finished`() = runBlockingSweetest {
         val channel = BroadcastChannel<Int>(1)
         val emissions = mutableListOf<Int>()
 
@@ -29,7 +42,5 @@ class FlowTestWithAutoCancel : BaseJUnitTest(appModuleTestingConfiguration) {
 
         channel.offer(1)
         assertEquals(1, emissions.size)
-
-        // After the test sweetest automatically cancels the job created by `launchIn`
     }
 }

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/FlowTestWithAutoCancel.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/FlowTestWithAutoCancel.kt
@@ -2,8 +2,8 @@ package com.mysugr.sweetest.coroutine
 
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
 import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
-import com.mysugr.sweetest.framework.coroutine.runBlockingSweetest
-import com.mysugr.sweetest.framework.coroutine.testCoroutineScope
+import com.mysugr.sweetest.framework.coroutine.coroutineScope
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BroadcastChannel
@@ -19,13 +19,13 @@ class FlowTestWithAutoCancel : BaseJUnitTest(moduleTestingConfiguration()) {
     override fun configure() = super.configure()
         .autoCancelTestCoroutines(true) // <-- !
 
-    fun `In contrast to FlowTest without auto cancel, here no exception is expected`() = runBlockingSweetest {
+    fun `In contrast to FlowTest without auto cancel, here no exception is expected`() = testCoroutine {
         val channel = BroadcastChannel<Int>(1)
         val emissions = mutableListOf<Int>()
 
         channel.asFlow()
             .onEach { emissions.add(it) }
-            .launchIn(testCoroutineScope)
+            .launchIn(coroutineScope)
 
         channel.offer(1)
         assertEquals(1, emissions.size)

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/FlowTestWithAutoCancel.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/FlowTestWithAutoCancel.kt
@@ -1,7 +1,7 @@
-package com.mysugr.android.testing.example.coroutine
+package com.mysugr.sweetest.coroutine
 
-import com.mysugr.android.testing.example.appModuleTestingConfiguration
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
 import com.mysugr.sweetest.framework.coroutine.runBlockingSweetest
 import com.mysugr.sweetest.framework.coroutine.testCoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,29 +10,16 @@ import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.test.UncompletedCoroutinesError
 import org.junit.Assert.assertEquals
-import org.junit.Test
 
 @ExperimentalCoroutinesApi
 @FlowPreview
-class FlowTest : BaseJUnitTest(appModuleTestingConfiguration) {
+class FlowTestWithAutoCancel : BaseJUnitTest(moduleTestingConfiguration()) {
 
-    @Test
-    fun `Hot Flow with TestCoroutineScope is successful`() {
-        val channel = BroadcastChannel<Int>(1)
-        val emissions = mutableListOf<Int>()
+    override fun configure() = super.configure()
+        .autoCancelTestCoroutines(true) // <-- !
 
-        channel.asFlow()
-            .onEach { emissions.add(it) }
-            .launchIn(testCoroutineScope)
-        channel.offer(1)
-
-        assertEquals(1, emissions.size)
-    }
-
-    @Test(expected = UncompletedCoroutinesError::class)
-    fun `Hot Flow produces error when not finished`() = runBlockingSweetest {
+    fun `In contrast to FlowTest without auto cancel, here no exception is expected`() = runBlockingSweetest {
         val channel = BroadcastChannel<Int>(1)
         val emissions = mutableListOf<Int>()
 
@@ -42,5 +29,7 @@ class FlowTest : BaseJUnitTest(appModuleTestingConfiguration) {
 
         channel.offer(1)
         assertEquals(1, emissions.size)
+
+        // After the test sweetest automatically cancels the job created by `launchIn`
     }
 }

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/UseCoroutineFeaturesTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/UseCoroutineFeaturesTest.kt
@@ -1,0 +1,42 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import com.mysugr.sweetest.framework.coroutine.coroutineScope
+import com.mysugr.sweetest.framework.coroutine.delayController
+import com.mysugr.sweetest.framework.coroutine.legacy.testCoroutine
+import com.mysugr.sweetest.framework.coroutine.uncaughtExceptionCaptor
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.Test
+import com.mysugr.sweetest.framework.coroutine.legacy.coroutineScope as legacyCoroutineScope
+import com.mysugr.sweetest.framework.coroutine.legacy.testCoroutine as legacyTestCoroutine
+
+class UseCoroutineFeaturesTest : BaseJUnitTest(moduleTestingConfiguration()) {
+
+    override fun configure() = super.configure()
+        .useLegacyCoroutineScope(false)
+
+    @Test
+    fun `Uses default TestCoroutineScope`() = testCoroutine {
+        assert(this is TestCoroutineScope)
+        assert(coroutineScope is TestCoroutineScope)
+    }
+
+    @Test
+    fun `Can access delayController`() = testCoroutine {
+        delayController
+    }
+
+    @Test
+    fun `Can access uncaughtExceptionCaptor`() = testCoroutine {
+        uncaughtExceptionCaptor
+    }
+
+    @Test
+    fun `Can access legacy testCoroutine`() = legacyTestCoroutine {}
+
+    @Test
+    fun `Can access legacy coroutineScope`() = legacyTestCoroutine {
+        legacyCoroutineScope
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/UseLegacyCoroutineFeaturesTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/UseLegacyCoroutineFeaturesTest.kt
@@ -1,0 +1,42 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import com.mysugr.sweetest.framework.coroutine.coroutineScope
+import com.mysugr.sweetest.framework.coroutine.delayController
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
+import com.mysugr.sweetest.framework.coroutine.uncaughtExceptionCaptor
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.Test
+import com.mysugr.sweetest.framework.coroutine.legacy.coroutineScope as legacyCoroutineScope
+import com.mysugr.sweetest.framework.coroutine.legacy.testCoroutine as legacyTestCoroutine
+
+class UseLegacyCoroutineFeaturesTest : BaseJUnitTest(moduleTestingConfiguration()) {
+
+    override fun configure() = super.configure()
+        .useLegacyCoroutineScope(true)
+
+    @Test
+    fun `Uses legacy CoroutineScope`() = legacyTestCoroutine {
+        assert(this !is TestCoroutineScope)
+        assert(legacyCoroutineScope !is TestCoroutineScope)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `Can't access delayController`() = legacyTestCoroutine {
+        delayController
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `Can't access uncaughtExceptionCaptor`() = legacyTestCoroutine {
+        uncaughtExceptionCaptor
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `Can't access original testCoroutine`() = testCoroutine {}
+
+    @Test(expected = IllegalStateException::class)
+    fun `Can't access original coroutineScope`() = legacyTestCoroutine {
+        coroutineScope
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/coroutine/UseLegacyCoroutineScopeConfigurationTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/coroutine/UseLegacyCoroutineScopeConfigurationTest.kt
@@ -1,0 +1,82 @@
+package com.mysugr.sweetest.coroutine
+
+import com.mysugr.sweetest.framework.coroutine.CoroutinesTestConfiguration
+import com.mysugr.sweetest.framework.coroutine.useLegacyTestCoroutineEnabled
+import com.mysugr.sweetest.framework.coroutine.useLegacyTestCoroutineEnabled
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UseLegacyCoroutineScopeConfigurationTest {
+
+    private val sut = CoroutinesTestConfiguration()
+
+    @Test
+    fun `useLegacyTestCoroutine is false by default`() {
+        assertFalse(sut.data.useLegacyTestCoroutineEnabled)
+    }
+
+    @Test
+    fun `useLegacyTestCoroutine is set to true`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(true)
+        assertTrue(sut.data.useLegacyTestCoroutineEnabled)
+    }
+
+    @Test
+    fun `useLegacyTestCoroutine is set to false`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(false)
+        assertFalse(sut.data.useLegacyTestCoroutineEnabled)
+    }
+
+    @Test
+    fun `useLegacyTestCoroutine is set to false two times on test level`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(false)
+        sut.useLegacyCoroutineScopeOnTestLevel(false)
+        assertFalse(sut.data.useLegacyTestCoroutineEnabled)
+    }
+
+    @Test
+    fun `useLegacyTestCoroutine is set to true two times on test level`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(true)
+        sut.useLegacyCoroutineScopeOnTestLevel(true)
+        assertTrue(sut.data.useLegacyTestCoroutineEnabled)
+    }
+
+    @Test
+    fun `useLegacyTestCoroutine is set to false two times on different levels`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(false)
+        sut.useLegacyCoroutineScopeOnStepsLevel(false)
+        assertFalse(sut.data.useLegacyTestCoroutineEnabled)
+    }
+
+    @Test
+    fun `useLegacyTestCoroutine is set to true two times on different levels`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(true)
+        sut.useLegacyCoroutineScopeOnStepsLevel(true)
+        assertTrue(sut.data.useLegacyTestCoroutineEnabled)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `useLegacyTestCoroutine can't be changed from true to false on test`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(true)
+        sut.useLegacyCoroutineScopeOnTestLevel(false)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `useLegacyTestCoroutine can't be changed from false to true on test`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(false)
+        sut.useLegacyCoroutineScopeOnTestLevel(true)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `useLegacyTestCoroutine can't be changed from true in test to false on steps`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(true)
+        sut.useLegacyCoroutineScopeOnStepsLevel(false)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `useLegacyTestCoroutine can't be changed from false in test to true on steps`() {
+        sut.useLegacyCoroutineScopeOnTestLevel(false)
+        sut.useLegacyCoroutineScopeOnStepsLevel(true)
+    }
+}


### PR DESCRIPTION
# Scope

- Update coroutines version
- Added coroutine test dependency
- Deprecate old `testCoroutine` and moved it to `legacy` sub-package
- Added `onTearDown` capability in workflow (was needed on the way)
- Configuration options added
  - `useLegacyCoroutineScope()` to use old-style `testCoroutine` (that needs to be specified in all tests which use the old `testCoroutine` function, that gives time for migration)
  - `autoSetMainCoroutineDispatcher(Boolean)` (default: true) - automatically calls `Dispatchers.setMain()`
  - `autoCancelTestCoroutines(Boolean)` closes open jobs after tests (default: false)
    - I struggle with the decision whether to put this to default: true. Doing that might hide exceptions that go unnoticed, e.g. when a job remains unintentionally active. In that case `runBlockingTest` would usually fail the test in case there are still some coroutines running. But when auto cancel is enabled there would be no such exception. But that's of course an extremely seldom problem. In case, there should be a test for whether the coroutine is still running. In general it would be more convenient to automatically cancel coroutines.
  - The two functions that receive a boolean value are implemented in a way that conflicting configurations lead to an exception, e.g. in steps A you say `true` and in steps B you say `false` for `autoCancelTestCoroutines`. Reasoning: each steps can lay out its intentions. If the intentions differ there is a conflict. You can compare it to dependencies, where you can set a dependency to be `requireMock<Z>`, so a subsequent call of `requireReal<Z>` would fail. Is the approach needed that way or overcomplicating things too much
- `Steps` don't implement `CoroutineScope` anymore (reason: `CoroutineScope` should only be implemented for things that really represent a kind of coroutine scope, but not to represent something that "has" a coroutine scope). Instead there is a new extension function `coroutineScope` which is available on steps _and_ tests. For the legacy version the extension from the `legacy` sub-package has to be used.

# ToDo

- [x] Code cleanup
- [x] Improve naming of `CoroutinesTestContextProvider `
- [x] Add more deprecation annotations 
- [x] Decide whether to use just `coroutineScope` or also `testCoroutineScope`
- [x] Unit tests