### PR TITLE
TestCoroutineScope support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
             buildTools  : '28.0.2',
             gradlePlugin: '3.1.3',
             kotlin      : '1.3.10',
-            coroutines  : '1.0.1',
+            coroutines  : '1.3.7',
             support     : '27.1.1',
             cucumber    : '2.1.0',
             espresso    : '3.0.2',

--- a/sweetest/build.gradle
+++ b/sweetest/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.coroutines"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$versions.coroutines"
     api "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
     api "org.mockito:mockito-core:$versions.mockito"
     api "io.cucumber:cucumber-junit:$versions.cucumber"

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
@@ -15,12 +15,21 @@ abstract class BaseSteps(
 
     open fun configure() = StepsBuilder(this, testContext, moduleTestingConfiguration)
 
+    @Deprecated(coroutineScopeImplementationDeprecation)
     override val coroutineContext: CoroutineContext
-        get() = testContext.legacyCoroutines.coroutineContext
+        get() {
+            println(coroutineScopeImplementationDeprecation)
+            return testContext.legacyCoroutines.coroutineContext
+        }
 
     override val accessor = configure().build()
     protected val dependencies = accessor.dependencies
     protected val delegates = accessor.delegates
+
+    companion object {
+        private const val coroutineScopeImplementationDeprecation = "Using steps class as CoroutineScope is " +
+            "deprecated, please use testCoroutineScope extension property instead!"
+    }
 }
 
 operator fun <T : Steps> T.invoke(run: T.() -> Unit) = run(this)

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/base/BaseSteps.kt
@@ -16,7 +16,7 @@ abstract class BaseSteps(
     open fun configure() = StepsBuilder(this, testContext, moduleTestingConfiguration)
 
     override val coroutineContext: CoroutineContext
-        get() = testContext.coroutines.coroutineContext
+        get() = testContext.legacyCoroutines.coroutineContext
 
     override val accessor = configure().build()
     protected val dependencies = accessor.dependencies

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/TestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/TestContext.kt
@@ -1,6 +1,7 @@
 package com.mysugr.sweetest.framework.context
 
 import com.mysugr.sweetest.framework.coroutine.CoroutinesTestContext
+import com.mysugr.sweetest.framework.coroutine.LegacyCoroutinesTestContext
 import com.mysugr.sweetest.framework.environment.TestEnvironment
 
 class TestContext internal constructor() {
@@ -17,11 +18,53 @@ class TestContext internal constructor() {
     @PublishedApi
     internal val dependencies = DependenciesTestContext()
 
-    internal val coroutines = CoroutinesTestContext()
-
     val workflow = WorkflowTestContext(steps)
+
+    private var _legacyCoroutines: LegacyCoroutinesTestContext? = null
+    internal val legacyCoroutines: LegacyCoroutinesTestContext
+        get() = getLegacyCoroutinesTestContext()
+
+    private var _coroutines: CoroutinesTestContext? = null
+    internal val coroutines: CoroutinesTestContext
+        get() = getCoroutinesTestContext()
 
     init {
         TestEnvironment.reset()
+    }
+
+    private fun getLegacyCoroutinesTestContext(): LegacyCoroutinesTestContext {
+        synchronized(this) {
+            check(_coroutines == null) { coroutinesLegacyErrorMessage }
+            if (_legacyCoroutines == null) {
+                _legacyCoroutines = LegacyCoroutinesTestContext()
+            }
+            return _legacyCoroutines!!
+        }
+    }
+
+    private fun getCoroutinesTestContext(): CoroutinesTestContext {
+        synchronized(this) {
+            check(_legacyCoroutines == null) { coroutinesLegacyErrorMessage }
+            if (_coroutines == null) {
+                _coroutines = CoroutinesTestContext(workflow)
+            }
+            return _coroutines!!
+        }
+    }
+
+    companion object {
+        val coroutinesLegacyErrorMessage: String = """
+        Can't use legacy and new coroutines tools side-by-side! 
+        
+        Legacy:
+        - BaseJUnitTest.testCoroutine { ... }
+        - BaseSteps.coroutineContext (using steps class as CoroutineScope)
+        
+        New:
+        - BaseJUnitTest.testCoroutineScope
+        - BaseJUnitTest.coroutineDispatcher
+        - BaseSteps.testCoroutineScope
+        - BaseSteps.coroutineDispatcher
+        """.trimIndent()
     }
 }

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/context/WorkflowTestContext.kt
@@ -4,14 +4,15 @@ import com.mysugr.sweetest.framework.flow.InitializationStep
 
 class WorkflowTestContext internal constructor(private val steps: StepsTestContext) {
 
-    private var currentStep: InitializationStep = InitializationStep.INITIALIZE_FRAMEWORK
+    internal var currentStep: InitializationStep = InitializationStep.INITIALIZE_FRAMEWORK
 
     private val supportedSubscriptionSteps = listOf(
         InitializationStep.INITIALIZE_STEPS,
         InitializationStep.INITIALIZE_DEPENDENCIES,
         InitializationStep.SET_UP,
         InitializationStep.RUNNING,
-        InitializationStep.TEAR_DOWN
+        InitializationStep.TEAR_DOWN,
+        InitializationStep.DONE
     )
 
     private val subscriptionHandlers =

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
@@ -1,0 +1,30 @@
+package com.mysugr.sweetest.framework.coroutine
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancelAndJoin
+import java.util.concurrent.Executors
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Experimental
+ */
+class LegacyCoroutinesTestContext {
+    private val name = CoroutineName("testCoroutine${instanceCounter++}")
+    private val supervisorJob = SupervisorJob()
+    val coroutineContext: CoroutineContext
+        get() = coroutineDispatcher + supervisorJob + name
+
+    suspend fun testFinished() {
+        supervisorJob.cancelAndJoin()
+    }
+
+    companion object {
+        val coroutineDispatcher: CoroutineDispatcher by lazy {
+            Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        }
+        private var instanceCounter = 0
+    }
+}

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/LegacyCoroutinesTestContext.kt
@@ -8,9 +8,6 @@ import kotlinx.coroutines.cancelAndJoin
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 
-/**
- * Experimental
- */
 class LegacyCoroutinesTestContext {
     private val name = CoroutineName("testCoroutine${instanceCounter++}")
     private val supervisorJob = SupervisorJob()

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -6,6 +6,7 @@ import com.mysugr.sweetest.framework.base.TestingAccessor
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -13,9 +14,11 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import kotlin.coroutines.ContinuationInterceptor
 
+@ExperimentalCoroutinesApi
 val TestingAccessor.testCoroutineScope: TestCoroutineScope
     get() = this.accessor.testContext.coroutines.testCoroutineScope
 
+@ExperimentalCoroutinesApi
 val TestingAccessor.coroutineDispatcher: CoroutineDispatcher
     get() = this.accessor.testContext.coroutines.testCoroutineScope
         .coroutineContext[ContinuationInterceptor] as CoroutineDispatcher

--- a/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/framework/coroutine/TestExtensions.kt
@@ -2,21 +2,33 @@ package com.mysugr.sweetest.framework.coroutine
 
 import com.mysugr.sweetest.framework.base.BaseJUnitTest
 import com.mysugr.sweetest.framework.base.Steps
+import com.mysugr.sweetest.framework.base.TestingAccessor
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
+import kotlin.coroutines.ContinuationInterceptor
 
-/**
- * Experimental
- */
+val TestingAccessor.testCoroutineScope: TestCoroutineScope
+    get() = this.accessor.testContext.coroutines.testCoroutineScope
+
+val TestingAccessor.coroutineDispatcher: CoroutineDispatcher
+    get() = this.accessor.testContext.coroutines.testCoroutineScope
+        .coroutineContext[ContinuationInterceptor] as CoroutineDispatcher
+
+@Deprecated(
+    "Legacy support only",
+    replaceWith = ReplaceWith("testCoroutineScope.runBlockingTest", "kotlinx.coroutines.test", "")
+)
 fun BaseJUnitTest.testCoroutine(
     testBlock: suspend CoroutineScope.() -> Unit
 ) {
     runBlocking {
-        val coroutinesTestContext = accessor.testContext.coroutines
+        val coroutinesTestContext = accessor.testContext.legacyCoroutines
         withContext(coroutinesTestContext.coroutineContext) {
             testBlock()
         }

--- a/sweetest/src/main/java/com/mysugr/sweetest/util/TestUtils.kt
+++ b/sweetest/src/main/java/com/mysugr/sweetest/util/TestUtils.kt
@@ -10,15 +10,21 @@ val Any.isMock get() = MockUtil.isMock(this)
 
 val Any.isSpy get() = MockUtil.isSpy(this)
 
-inline fun <reified TException : Exception> expectException(block: () -> Unit) {
+// Internal for now as there is no decision yet whether to keep these assertions as public tools
+internal inline fun <reified TThrowable : Throwable> assertThrown(block: () -> Unit) =
+    expectException<TThrowable>(block)
+
+inline fun <reified TThrowable : Throwable> expectException(block: () -> Unit) {
     try {
         block()
-        fail("Expected exception of type ${TException::class.simpleName}, but no exception was thrown")
+        fail("Expected throwable of type ${TThrowable::class.simpleName}, but not thrown.")
     } catch (e: Exception) {
-        if (e !is TException) {
-            fail("Wrong exception type.\n" +
-                    "expected: ${TException::class.simpleName}\n" +
-                    "actual: ${e::class.simpleName}")
+        if (e !is TThrowable) {
+            fail(
+                "Unexpected throwable type.\n" +
+                    "    Expected: ${TThrowable::class.simpleName}\n" +
+                    "    Actual: ${e::class.simpleName}"
+            )
         }
     }
 }

--- a/sweetest/src/test/java/com/mysugr/sweetest/CoroutinesTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/CoroutinesTest.kt
@@ -1,0 +1,87 @@
+package com.mysugr.sweetest
+
+import com.mysugr.sweetest.framework.base.BaseJUnitTest
+import com.mysugr.sweetest.framework.base.BaseSteps
+import com.mysugr.sweetest.framework.base.steps
+import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
+import com.mysugr.sweetest.framework.context.TestContext
+import com.mysugr.sweetest.framework.coroutine.coroutineDispatcher
+import com.mysugr.sweetest.framework.coroutine.testCoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.UncompletedCoroutinesError
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.coroutines.ContinuationInterceptor
+
+class CoroutinesTest {
+
+    class Steps(testContext: TestContext) : BaseSteps(testContext, moduleConfig)
+
+    @Test
+    fun `Create TestCoroutineScope`() {
+        val test = object : BaseJUnitTest(moduleTestingConfiguration()) {}
+        test.testCoroutineScope.smokeTest()
+    }
+
+    @Test
+    fun `Get CoroutineDispatcher from TestCoroutineScope`() {
+        val test = object : BaseJUnitTest(moduleTestingConfiguration()) {}
+        val expected = test.testCoroutineScope.coroutineContext[ContinuationInterceptor] as
+            CoroutineDispatcher
+        val actual = test.coroutineDispatcher
+        assertSame(expected, actual)
+    }
+
+    @Test
+    fun `Just creates one instance (singleton)`() {
+        val test = object : BaseJUnitTest(moduleTestingConfiguration()) {}
+
+        assertSame(test.testCoroutineScope, test.testCoroutineScope)
+        assertSame(test.coroutineDispatcher, test.coroutineDispatcher)
+    }
+
+    @Test
+    fun `It doesn't matter whether you get it on the test or steps level`() {
+        val test = object : BaseJUnitTest(moduleConfig) {
+            val steps by steps<Steps>()
+        }
+
+        test.junitBefore()
+
+        assertSame(test.testCoroutineScope, test.steps.testCoroutineScope)
+        assertSame(test.coroutineDispatcher, test.steps.coroutineDispatcher)
+    }
+
+    // TODO couldn't manage to provoke the wanted exception yet
+    @Test(expected = UncompletedCoroutinesError::class)
+    fun `Cleans up TestCoroutineScope`() {
+        val test = object : BaseJUnitTest(moduleConfig) {}
+
+        test.junitBefore()
+
+        GlobalScope.launch {
+            Thread.sleep(1000)
+            test.junitAfter()
+        }
+
+        CoroutineScope(test.coroutineDispatcher).launch {
+            Thread.sleep(2000)
+        }
+    }
+
+    private fun TestCoroutineScope.smokeTest() {
+        var executed = false
+        this.async { executed = true }
+        assertTrue(executed)
+    }
+
+    companion object {
+        private val moduleConfig = moduleTestingConfiguration()
+    }
+}

--- a/sweetest/src/test/java/com/mysugr/sweetest/TestCoroutineScopeTest.kt
+++ b/sweetest/src/test/java/com/mysugr/sweetest/TestCoroutineScopeTest.kt
@@ -6,6 +6,7 @@ import com.mysugr.sweetest.framework.base.steps
 import com.mysugr.sweetest.framework.configuration.moduleTestingConfiguration
 import com.mysugr.sweetest.framework.context.TestContext
 import com.mysugr.sweetest.framework.coroutine.coroutineDispatcher
+import com.mysugr.sweetest.framework.coroutine.testCoroutine
 import com.mysugr.sweetest.framework.coroutine.testCoroutineScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -19,7 +20,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.coroutines.ContinuationInterceptor
 
-class CoroutinesTest {
+class TestCoroutineScopeTest {
 
     class Steps(testContext: TestContext) : BaseSteps(testContext, moduleConfig)
 
@@ -71,8 +72,23 @@ class CoroutinesTest {
         }
 
         CoroutineScope(test.coroutineDispatcher).launch {
+            throw Exception("test")
             Thread.sleep(2000)
         }
+    }
+
+    @Test(expected = Exception::class)
+    fun `Legacy coroutine scope tools don't work together with TestCoroutineScope support`() {
+        val test = object : BaseJUnitTest(moduleTestingConfiguration()) {}
+        test.testCoroutineScope
+        test.testCoroutine { }
+    }
+
+    @Test(expected = Exception::class)
+    fun `TestCoroutineScope support doesn't work together with legacy coroutine scope tools`() {
+        val test = object : BaseJUnitTest(moduleTestingConfiguration()) {}
+        test.testCoroutine { }
+        test.testCoroutineScope
     }
 
     private fun TestCoroutineScope.smokeTest() {


### PR DESCRIPTION
## ToDo

- [x] should we add the experimental annotations?
- [x] have just `coroutineDispatcher` as it is currently or make it an extension on `TestCoroutineScope`(e.g. `TestCoroutineScope.dispatcher`)?
- [x] naming: `testCoroutineScope`, `testScope`, `scope`, `coroutineScope`?
- [x] deprecation annotations and println messages
- [ ] test correct integration into product